### PR TITLE
New plams

### DIFF
--- a/src/qmflows/packages/SCM.py
+++ b/src/qmflows/packages/SCM.py
@@ -8,7 +8,6 @@ from qmflows.settings import Settings
 from qmflows.packages.packages import (Package, package_properties, Result, get_tmpfile_name)
 from scm import plams
 
-import builtins
 import struct
 
 # ========================= ADF ============================
@@ -254,7 +253,7 @@ class DFTB(Package):
             print(msg.format(job_name))
 
         if job.status in ['failed', 'crashed']:
-            builtins.config.jm.remove_job(job)
+            plams.config.jm.remove_job(job)
 
         return DFTB_Result(dftb_settings, mol, name,
                            plams_dir=path, status=job.status)

--- a/src/qmflows/packages/packages.py
+++ b/src/qmflows/packages/packages.py
@@ -364,7 +364,6 @@ def run(job, runner=None, path=None, folder=None, **kwargs):
         plams.init(path=path, folder=folder)
         initialize = True
     plams.config.log.stdout = 0
-    plams.config.jobmanager.jobfolder_exists = 'rename'
     if runner is None:
         ret = call_default(job, **kwargs)
     # elif runner.lower() == 'xenon':

--- a/src/qmflows/packages/packages.py
+++ b/src/qmflows/packages/packages.py
@@ -12,7 +12,6 @@ from scm import plams
 from typing import (Any, Callable, Dict, List)
 
 import base64
-import builtins
 import fnmatch
 import importlib
 import inspect
@@ -354,7 +353,7 @@ def run(job, runner=None, path=None, folder=None, **kwargs):
 
     initialize = False
     try:
-        config = builtins.config
+        config = plams.config
         if path and os.path.abspath(path) != config.jm.path or \
                 folder and folder != config.jm.folder:
             msg = "Reinitializing Plams with new path and/or folder name.\n"
@@ -364,8 +363,8 @@ def run(job, runner=None, path=None, folder=None, **kwargs):
     except AttributeError:
         plams.init(path=path, folder=folder)
         initialize = True
-    builtins.config.log.stdout = 0
-    builtins.config.jobmanager.jobfolder_exists = 'rename'
+    plams.config.log.stdout = 0
+    plams.config.jobmanager.jobfolder_exists = 'rename'
     if runner is None:
         ret = call_default(job, **kwargs)
     # elif runner.lower() == 'xenon':
@@ -519,7 +518,7 @@ def find_file_pattern(pat, folder):
 
 
 def get_tmpfile_name():
-    tmpfolder = builtins.config.jm.workdir + '/tmpfiles'
+    tmpfolder = plams.config.jm.workdir + '/tmpfiles'
     if not os.path.exists(tmpfolder):
         os.mkdir(tmpfolder)
     return tmpfolder + '/' + str(uuid.uuid4())

--- a/src/qmflows/utils.py
+++ b/src/qmflows/utils.py
@@ -10,7 +10,6 @@ from itertools import chain
 from pymonad   import curry
 from scm import plams
 
-import builtins
 # ======================> List Functions <========================
 
 
@@ -110,11 +109,9 @@ def initialize(fun):
     """
     @wraps(fun)
     def wrapper(*args, **kwargs):
-        try:
-            builtins.config
-        except AttributeError:
+        if not plams.config:
             plams.init()
-        builtins.config.log.stdout = 0
+        plams.config.log.stdout = 0
         result = fun(*args, **kwargs)
         plams.finish()
         return result


### PR DESCRIPTION
Hi guys!
Many people complained about the default PLAMS behavior wrt main working directory name (plams.[pid]) so I decided to change it to more predictable: `plams_workdir`, `plams_workdir.002`, `plams_workdir.003`. So now every time `plams.init()` is called it is pretty much guaranteed that the working folder is fresh and unique.

Also, I decided to move `config` object away from `builtins` (it was just a bad dirty idea)  

This pull request contains changes I believe are enough to keep QMFlows working, but I'd be grateful for a bit of testing from your side. Could you please check if these modifications work well with https://github.com/SCM-NV/PLAMS/commit/5d691f17054c874475af20997096c5dfd56fa71f