### PR TITLE
Added init_restart() and InitRestart()

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -77,3 +77,6 @@ pytest*
 .ds_store
 .DS_Store
 scripts/.DS_Store
+
+# mypy
+.mypy_cache/

--- a/src/qmflows/utils.py
+++ b/src/qmflows/utils.py
@@ -77,7 +77,26 @@ def init_restart(path: Union[None, AnyStr, os.PathLike] = None,
 
 
 class InitRestart(AbstractContextManager):
-    """A context manager wrapper around :func:`init_restart`."""
+    """A context manager wrapper around :func:`init_restart`.
+
+    Examples
+    --------
+    .. code:: python
+
+        >>> path = "path/to/my/workdir"
+        >>> with InitRestart(path):
+        ...     ...  # Run any PLAMS Jobs here
+
+    See Also
+    --------
+    :func:`init<scm.plams.core.functions.init>`:
+        Initialize PLAMS environment. Create global ``config`` and the default
+        :class:`JobManager<scm.plams.core.jobmanager.JobManager>`.
+
+    :func:`finish<scm.plams.core.functions.finish>`:
+        Wait for all threads to finish and clean the environment.
+
+    """
 
     def __init__(self, path: Union[None, AnyStr, os.PathLike] = None,
                  folder: Union[None, AnyStr, os.PathLike] = None,

--- a/test/test_restart_init.py
+++ b/test/test_restart_init.py
@@ -3,7 +3,7 @@ import pathlib
 from os.path import isdir
 
 from qmflows.utils import init_restart, InitRestart
-from scm.plams import init, finish, config
+from scm.plams import init, finish
 
 PATH = pathlib.Path('test') / 'test_files'
 

--- a/test/test_restart_init.py
+++ b/test/test_restart_init.py
@@ -1,0 +1,29 @@
+import shutil
+import pathlib
+from os.path import isdir
+
+from qmflows.utils import init_restart, InitRestart
+from scm.plams import init, finish, config
+
+PATH = pathlib.Path('test') / 'test_files'
+
+
+def test_restart_init() -> None:
+    """Tests for :func:`restart_init` and :class:`RestartInit`."""
+    workdir = PATH / 'plams_workdir'
+    try:
+        init(PATH)
+        finish()
+        assert isdir(workdir)
+
+        init_restart(PATH)
+        assert isdir(workdir)
+        assert not isdir(f'{workdir}.002')
+
+        with InitRestart(PATH):
+            assert isdir(workdir)
+            assert not isdir(f'{workdir}.002')
+
+    finally:
+        shutil.rmtree(workdir) if isdir(workdir) else None
+        shutil.rmtree(f'{workdir}.002') if isdir(f'{workdir}.002') else None


### PR DESCRIPTION
Added the ``init_restart()`` function and ``InitRestart()`` context manager for calling the PLAMS [``init()``](https://www.scm.com/doc/plams/components/functions.html#scm.plams.core.functions.init) function without creating a new directory.