### PR TITLE
Package & Result additions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -83,3 +83,6 @@ scripts/.DS_Store
 
 # vscode
 .vscode
+
+# Spyder
+.spyproject/

--- a/src/qmflows/packages/SCM.py
+++ b/src/qmflows/packages/SCM.py
@@ -2,12 +2,14 @@ __all__ = ['ADF_Result', 'DFTB_Result', 'adf', 'dftb']
 
 # =======>  Standard and third party Python Libraries <======
 
-from os import sep
+import os
 from os.path import join
 from warnings import warn
+from typing import Optional, Union, Any
+
 from scm import plams
 from ..settings import Settings
-from .packages import (Package, package_properties, Result, get_tmpfile_name)
+from .packages import (Package, package_properties, Result, get_tmpfile_name, WarnMap)
 
 import struct
 
@@ -15,23 +17,24 @@ import struct
 
 
 class ADF(Package):
-    """
+    """:class:`Package<qmflows.packages.Package>` subclass for ADF.
+
     This class takes care of calling the *ADF* quantum package.
     it uses both Plams and the Templates module to create the input
     files, while Plams takes care of running the Job.
     It returns a ``ADF_Result`` object containing the output data.
+
     """
-    def __init__(self):
+
+    def __init__(self) -> None:
         super(ADF, self).__init__("adf")
         self.generic_dict_file = 'generic2ADF.json'
 
-    def prerun(self):
-        pass
-
     @staticmethod
-    def run_job(settings, mol, job_name='ADFjob', nproc=None):
-        """
-        Execute ADF job.
+    def run_job(settings: Settings, mol: plams.Molecule,
+                job_name: str = 'ADFjob', nproc: Optional[int] = None,
+                **kwargs: Any) -> 'ADF_Result':
+        """Execute ADF job.
 
         :param settings: user input settings.
         :type settings: |Settings|
@@ -44,6 +47,7 @@ class ADF(Package):
                                   job output.
         :type out_file_name: String
         :returns: :class:`~qmflows.packages.SCM.ADF_Result`
+
         """
         adf_settings = Settings()
         if nproc:
@@ -56,10 +60,10 @@ class ADF(Package):
         path_t21 = result._kf.path
 
         # Relative path to the CWD
-        relative_path_t21 = sep.join(path_t21.split(sep)[-3:])
+        relative_path_t21 = join(*str(path_t21).split(os.sep)[-3:])
 
         # Relative job path
-        relative_plams_path = join(*str(result.job.path).split(sep)[-2:])
+        relative_plams_path = join(*str(result.job.path).split(os.sep)[-2:])
 
         # Absolute path to the .dill file
         dill_path = join(job.path, f'{job.name}.dill')
@@ -70,20 +74,20 @@ class ADF(Package):
 
         return adf_result
 
-    def postrun(self):
-        pass
-
     @staticmethod
-    def handle_special_keywords(settings, key, value, mol):
-        """
-        some keywords provided by the user do not have a straightforward
+    def handle_special_keywords(settings: Settings, key: str,
+                                value: Any, mol: plams.Molecule) -> None:
+        """Handle special ADF-specific keywords.
+
+        Some keywords provided by the user do not have a straightforward
         translation to *ADF* input and require some hooks that handles the
         special behaviour of the following keywords:
 
         * ``freeze``
         * ``selected_atoms``
+
         """
-        def freeze():
+        def freeze() -> None:
             settings.specific.adf.geometry.optim = "cartesian"
             if not isinstance(value, list):
                 msg = 'freeze ' + str(value) + ' is not a list'
@@ -98,7 +102,7 @@ class ADF(Package):
                         at = 'atom ' + str(a + 1)
                         settings.specific.adf.constraints[at] = ""
 
-        def selected_atoms():
+        def selected_atoms() -> None:
             settings.specific.adf.geometry.optim = "cartesian"
             if not isinstance(value, list):
                 msg = f'selected_atoms {value} is not a list'
@@ -114,13 +118,13 @@ class ADF(Package):
                         at = 'atom ' + str(a + 1)
                         settings.specific.adf.constraints[at] = ""
 
-        def inithess():
+        def inithess() -> None:
             hess_path = get_tmpfile_name()
             hess_file = open(hess_path, "w")
             hess_file.write(" ".join(['{:.6f}'.format(v) for v in value]))
             settings.specific.adf.geometry.inithess = hess_path
 
-        def constraint():
+        def constraint() -> None:
             if isinstance(value, Settings):
                 for k, v in value.items():
                     ks = k.split()
@@ -155,26 +159,38 @@ class ADF(Package):
 
 
 class ADF_Result(Result):
-    """Class providing access to PLAMS ADFJob result results"""
+    """Class providing access to PLAMS ADFJob result results."""
 
-    def __init__(self, settings, molecule, job_name, path_t21, dill_path,
-                 plams_dir=None, status='done', warnings=None):
+    def __init__(self, settings: Optional[Settings],
+                 molecule: Optional[plams.Molecule],
+                 job_name: str,
+                 path_t21: Union[str, os.PathLike],
+                 dill_path: Union[None, str, os.PathLike] = None,
+                 plams_dir: Union[None, str, os.PathLike] = None,
+                 work_dir: Union[None, str, os.PathLike] = None,
+                 status: str = 'done',
+                 warnings: Optional[WarnMap] = None) -> None:
         # Load available property parser from Json file.
-        properties = package_properties['adf']
         super().__init__(settings, molecule, job_name, dill_path,
-                         plams_dir=plams_dir, properties=properties,
+                         plams_dir=plams_dir, properties=package_properties['adf'],
                          status=status, warnings=warnings)
 
         # Create a KF reader instance
         self.kf = plams.KFFile(path_t21)
 
-    def get_property_kf(self, prop, section=None):
+    def get_property_kf(self, prop: str, section: Optional[str] = None) -> Any:
+        """Interface for :meth:`plams.KFFile.read()<scm.plams.tools.kftools.KFFile.read>`."""
         return self.kf.read(section, prop)
 
     @property
-    def molecule(self, unit='bohr', internal=False, n=1):
-        """WARNING: Cheap copy from PLAMS, do not keep this!!!"""
-        m = self._molecule.copy()
+    def molecule(self, unit: str = 'bohr',
+                 internal: bool = False,
+                 n: int = 1) -> Optional[plams.Molecule]:
+        """WARNING: Cheap copy from PLAMS, do not keep this!!!."""
+        try:
+            m = self._molecule.copy()
+        except AttributeError:
+            return None  # self._molecule can be None
         natoms = len(m)
         # Find out correct location
         coords = self.kf.read('Geometry', 'xyz InputOrder')
@@ -192,20 +208,18 @@ class ADF_Result(Result):
 
 
 class DFTB(Package):
-    """
-    Add some documentation to this class
-    """
-    def __init__(self):
+    """:class:`Package<qmflows.packages.Package>` subclass for DFTB."""
+
+    def __init__(self) -> None:
         super().__init__("dftb")
         self.generic_dict_file = 'generic2DFTB.json'
 
-    def prerun(self):
-        pass
-
     @staticmethod
-    def run_job(settings, mol, job_name='DFTBjob', nproc=None):
-        """
-        Execute an DFTB job with the *ADF* quantum package.
+    def run_job(settings: Settings, mol: plams.Molecule,
+                job_name: str = 'DFTBjob',
+                nproc: Optional[int] = None,
+                **kwargs: Any) -> 'DFTB_Result':
+        """Execute an DFTB job with the *ADF* quantum package.
 
         :param settings: user input settings.
         :type settings: |Settings|
@@ -218,6 +232,7 @@ class DFTB(Package):
                                  job output.
         :type out_file_name: String
         :returns: :class:`~qmflows.packages.SCM.DFTB_Result`
+
         """
         dftb_settings = Settings()
         if nproc:
@@ -245,15 +260,11 @@ class DFTB(Package):
         return DFTB_Result(dftb_settings, mol, name, dill_path,
                            plams_dir=path, status=job.status)
 
-    def postrun(self):
-        pass
-
     @staticmethod
-    def handle_special_keywords(settings, key, value, mol):
-        """
-        Translate generic keywords to their corresponding Orca keywords.
-        """
-        def freeze():
+    def handle_special_keywords(settings: Settings, key: str,
+                                value: Any, mol: plams.Molecule) -> None:
+        """Translate generic keywords to their corresponding Orca keywords."""
+        def freeze() -> None:
             settings.specific.dftb.geometry.optim = "cartesian"
             if not isinstance(value, list):
                 raise RuntimeError(f'freeze {value} is not a list')
@@ -267,7 +278,7 @@ class DFTB(Package):
                         at = 'atom ' + str(a + 1)
                         settings.specific.dftb.constraints[at] = ""
 
-        def selected_atoms():
+        def selected_atoms() -> None:
             settings.specific.dftb.geometry.optim = "cartesian"
             if not isinstance(value, list):
                 raise RuntimeError(f'selected_atoms {value} is not a list')
@@ -282,7 +293,7 @@ class DFTB(Package):
                         name = 'atom ' + str(a + 1)
                         settings.specific.dftb.constraints[name] = ""
 
-        def constraint():
+        def constraint() -> None:
             if isinstance(value, Settings):
                 for k, v in value.items():
                     ks = k.split()
@@ -313,14 +324,19 @@ class DFTB(Package):
 
 
 class DFTB_Result(Result):
-    """Class providing access to PLAMS DFTBJob result results"""
+    """Class providing access to PLAMS DFTBJob result results."""
 
-    def __init__(self, settings, molecule, job_name, dill_path,
-                 plams_dir=None, status='done', warnings=None):
+    def __init__(self, settings: Optional[Settings],
+                 molecule: Optional[plams.Molecule],
+                 job_name: str,
+                 dill_path: Union[None, str, os.PathLike] = None,
+                 plams_dir: Union[None, str, os.PathLike] = None,
+                 work_dir: Union[None, str, os.PathLike] = None,
+                 status: str = 'done',
+                 warnings: Optional[WarnMap] = None) -> None:
         # Read available propiety parsers from a JSON file
-        properties = package_properties['dftb']
         super().__init__(settings, molecule, job_name, dill_path,
-                         plams_dir=plams_dir, properties=properties,
+                         plams_dir=plams_dir, properties=package_properties['dftb'],
                          status=status, warnings=warnings)
 
         if plams_dir is not None:
@@ -331,7 +347,9 @@ class DFTB_Result(Result):
             self.kf = None
 
     @property
-    def molecule(self, unit='bohr', internal=False, n=1):
+    def molecule(self, unit: str = 'bohr',
+                 internal: bool = False,
+                 n: int = 1) -> plams.Molecule:
         m = self._molecule.copy()
         natoms = len(m)
         coords = self.kf.read('Molecule', 'Coords')

--- a/src/qmflows/packages/SCM.py
+++ b/src/qmflows/packages/SCM.py
@@ -59,7 +59,7 @@ class ADF(Package):
         relative_path_t21 = sep.join(path_t21.split(sep)[-3:])
 
         # Relative job path
-        relative_plams_path = sep.join(result.job.path.split(sep)[-2:])
+        relative_plams_path = join(*str(result.job.path).split(sep)[-2:])
 
         # Absolute path to the .dill file
         dill_path = join(job.path, f'{job.name}.dill')

--- a/src/qmflows/packages/cp2k_package.py
+++ b/src/qmflows/packages/cp2k_package.py
@@ -1,6 +1,8 @@
 """CP2K input/output handling."""
 __all__ = ['CP2K_Result', 'cp2k']
 
+from os.path import join
+
 from scm import plams
 
 from ..parsers.cp2KParser import parse_cp2k_warnings
@@ -75,9 +77,11 @@ class CP2K(Package):
         warnings = parse_output_warnings(job_name, r.job.path,
                                          parse_cp2k_warnings, cp2k_warnings)
 
-        result = CP2K_Result(cp2k_settings, mol, job_name, r.job.path,
-                             work_dir, status=job.status, warnings=warnings)
+        # Absolute path to the .dill file
+        dill_path = join(job.path, f'{job.name}.dill')
 
+        result = CP2K_Result(cp2k_settings, mol, job_name, r.job.path, dill_path,
+                             work_dir=work_dir, status=job.status, warnings=warnings)
         return result
 
     def postrun(self):
@@ -147,8 +151,7 @@ class CP2K(Package):
                 abc = ' [angstrom] {} {} {}'.format(*value)
                 s.specific.cp2k.force_eval.subsys.cell.ABC = abc
             else:
-                msg = "cell parameter:{}\nformat not recognized"
-                RuntimeError(msg)
+                RuntimeError("cell parameter:{}\nformat not recognized")
 
             return s
 
@@ -165,10 +168,10 @@ class CP2K(Package):
 class CP2K_Result(Result):
     """Class providing access to CP2K result."""
 
-    def __init__(self, settings, molecule, job_name, plams_dir, work_dir=None,
-                 properties=package_properties['cp2k'],
+    def __init__(self, settings, molecule, job_name, plams_dir, dill_path,
+                 work_dir=None, properties=package_properties['cp2k'],
                  status='successful', warnings=None):
-        super().__init__(settings, molecule, job_name, plams_dir,
+        super().__init__(settings, molecule, job_name, plams_dir, dill_path,
                          work_dir=work_dir, properties=properties,
                          status=status, warnings=warnings)
 

--- a/src/qmflows/packages/cp2k_package.py
+++ b/src/qmflows/packages/cp2k_package.py
@@ -151,7 +151,7 @@ class CP2K(Package):
                 abc = ' [angstrom] {} {} {}'.format(*value)
                 s.specific.cp2k.force_eval.subsys.cell.ABC = abc
             else:
-                RuntimeError("cell parameter:{}\nformat not recognized")
+                raise RuntimeError("cell parameter:{}\nformat not recognized")
 
             return s
 

--- a/src/qmflows/packages/gamess.py
+++ b/src/qmflows/packages/gamess.py
@@ -1,6 +1,7 @@
 __all__ = ['gamess']
 
 from os import sep
+from os.path import join
 from warnings import warn
 
 from scm import plams

--- a/src/qmflows/packages/gamess.py
+++ b/src/qmflows/packages/gamess.py
@@ -48,14 +48,13 @@ class GAMESS(Package):
         r = job.run()
 
         # Relative job path
-        relative_plams_path = sep.join(r.job.path.split(sep)[-2:])
+        relative_plams_path = join(*str(r.job.path).split(sep)[-2:])
 
         # Absolute path to the .dill file
         dill_path = join(job.path, f'{job.name}.dill')
 
         result = Gamess_Result(gamess_settings, mol, r.job.name, relative_plams_path,
-                               dill_path,
-                               work_dir=work_dir, status=job.status)
+                               dill_path, work_dir=work_dir, status=job.status)
         return result
 
     def postrun(self):

--- a/src/qmflows/packages/gamess.py
+++ b/src/qmflows/packages/gamess.py
@@ -1,35 +1,37 @@
+"""Gamess-US input/output handling."""
 __all__ = ['gamess']
 
-from os import sep
+import os
 from os.path import join
 from warnings import warn
+from typing import Any, Union, Optional
 
 from scm import plams
 
-from .packages import (Package, package_properties, Result)
+from .packages import (Package, package_properties, Result, WarnMap)
 from ..settings import Settings
 
 
 class GAMESS(Package):
-    """
-    This class setup the requirement to run a Gamess-US Job
-    <http://www.msg.ameslab.gov/gamess/>.
+    """This class setup the requirement to run a Gamess-US Job <http://www.msg.ameslab.gov/gamess/>.
+
     It uses plams together with the templates to generate the stucture input
     and also uses Plams to invoke the ``rungms`` script.
     This class is not intended to be called directly by the user, instead the
     **gamess** function should be called.
+
     """
-    def __init__(self):
+
+    def __init__(self) -> None:
         super(GAMESS, self).__init__("gamess")
         self.generic_dict_file = 'generic2gamess.json'
 
-    def prerun(self):
-        pass
-
     @staticmethod
-    def run_job(settings, mol, job_name='gamess_job', work_dir=None):
-        """
-        Call the Cp2K binary using plams interface.
+    def run_job(settings: Settings, mol: plams.Molecule,
+                job_name: str = 'gamess_job',
+                work_dir: Union[None, str, os.PathLike] = None,
+                **kwargs: Any) -> 'Gamess_Result':
+        """Call the Cp2K binary using plams interface.
 
         :param settings: Job Settings.
         :type settings: :class:`~qmflows.Settings`
@@ -40,6 +42,7 @@ class GAMESS(Package):
         :param out_file_name: Optional name for the output.
         :type out_file_name: String
         :return: Package.Result
+
         """
         gamess_settings = Settings()
         gamess_settings.input = settings.specific.gamess
@@ -48,7 +51,7 @@ class GAMESS(Package):
         r = job.run()
 
         # Relative job path
-        relative_plams_path = join(*str(r.job.path).split(sep)[-2:])
+        relative_plams_path = join(*str(r.job.path).split(os.sep)[-2:])
 
         # Absolute path to the .dill file
         dill_path = join(job.path, f'{job.name}.dill')
@@ -57,13 +60,11 @@ class GAMESS(Package):
                                dill_path, work_dir=work_dir, status=job.status)
         return result
 
-    def postrun(self):
-        pass
-
     @staticmethod
-    def handle_special_keywords(settings, key, value, mol):
-        """
-        Create the settings input for complex gamess-us keys.
+    def handle_special_keywords(settings: Settings, key: str,
+                                value: Any, mol: plams.Molecule) -> None:
+        """Create the settings input for complex gamess-us keys.
+
         some keywords provided by the user do not have a straightforward
         translation to *GAMESS* input and require some hooks that handle the
         special behaviour of the following keywords:
@@ -77,16 +78,17 @@ class GAMESS(Package):
         :param value: Value store in ``settings``.
         :param mol: molecular Geometry
         :type mol: plams Molecule
+
         """
-        def freeze():
+        def freeze() -> None:
             if not isinstance(value, list):
                 msg = 'selected_atoms ' + str(value) + ' is not a list'
                 raise RuntimeError(msg)
             sel_coords = []
             if isinstance(value[0], int):
                 for v in value:
-                        a = v - 1
-                        sel_coords += [str(i) for i in range(a * 3 + 1, a * 3 + 4)]
+                    a = v - 1
+                    sel_coords += [str(i) for i in range(a * 3 + 1, a * 3 + 4)]
             else:
                 for a in range(len(mol)):
                     if mol[a + 1].symbol in value:
@@ -95,7 +97,7 @@ class GAMESS(Package):
             ifreez.statpt = "IFREEZ(1)=" + ",".join(sel_coords)
             settings.specific.gamess.update(ifreez)
 
-        def selected_atoms():
+        def selected_atoms() -> None:
             if not isinstance(value, list):
                 msg = 'selected_atoms ' + str(value) + ' is not a list'
                 raise RuntimeError(msg)
@@ -112,7 +114,7 @@ class GAMESS(Package):
             ifreez.statpt = "IFREEZ(1)=" + ",".join(sel_coords)
             settings.specific.gamess.update(ifreez)
 
-        def constraint():
+        def constraint() -> None:
             if isinstance(value, Settings):
                 s = Settings()
                 if len(mol) == 2:
@@ -149,6 +151,7 @@ class GAMESS(Package):
                         warn(f'Invalid constraint key: {k}')
                     i += 1
                 settings.specific.gamess.zmat = s
+
         # Available translations
         functions = {'freeze': freeze,
                      'selected_atoms': selected_atoms,
@@ -160,24 +163,31 @@ class GAMESS(Package):
 
 
 class Gamess_Result(Result):
-    """
-    Class providing access to CP2K result.
-    """
-    def __init__(self, settings, molecule, job_name, dill_path,
-                 plams_dir=None, work_dir=None, status='done', warnings=None):
-        properties = package_properties['gamess']
+    """Class providing access to Gamess result."""
+
+    def __init__(self, settings: Optional[Settings],
+                 molecule: Optional[plams.Molecule],
+                 job_name: str,
+                 dill_path: Union[None, str, os.PathLike] = None,
+                 plams_dir: Union[None, str, os.PathLike] = None,
+                 work_dir: Union[None, str, os.PathLike] = None,
+                 status: str = 'done',
+                 warnings: Optional[WarnMap] = None) -> None:
         super().__init__(settings, molecule, job_name, plams_dir, dill_path,
-                         work_dir=work_dir, properties=properties,
+                         work_dir=work_dir, properties=package_properties['gamess'],
                          status=status, warnings=warnings)
 
-    def __getattr__(self, prop):
-        """Returns a section of the results.
+    def __getattr__(self, prop: str) -> Any:
+        """Return a section of the results.
+
         The property is extracted from a  result file, which is recursively
         search for in the GAMESS settings
 
-        Example:
-        ..
+        For example:
+
+        ..code:: python
             Hessian_matrix = result.hessian
+
         """
         result = super().__getattr__(prop)
         if result is None:

--- a/src/qmflows/packages/orca.py
+++ b/src/qmflows/packages/orca.py
@@ -44,7 +44,7 @@ class ORCA(Package):
         result = job.run()
 
         # Relative job path
-        relative_plams_path = sep.join(result.job.path.split(sep)[-2:])
+        relative_plams_path = join(*str(result.job.path).split(sep)[-2:])
 
         # Absolute path to the .dill file
         dill_path = join(job.path, f'{job.name}.dill')

--- a/src/qmflows/packages/packages.py
+++ b/src/qmflows/packages/packages.py
@@ -89,7 +89,7 @@ class Result:
         plams_dir = None if plams_dir is None else Path(plams_dir)
         self.settings = settings
         self._molecule = molecule
-        xs = pkg.resource_string("qmflows", properties)
+        xs = pkg.resource_string("qmflows", str(properties))
         self.prop_dict = json2Settings(xs)
         self.archive = {"plams_dir": plams_dir,
                         'work_dir': work_dir}


### PR DESCRIPTION
Major
------
* Added the ``dill_path`` keyword to ``Package.__init__()`` and it's subclasses. It should take the path to a pickled ``plams.Results`` instance as value (_i.e._ the ``.dill`` file) and store it in the new ``Package.results`` property.
* The Results-containing .dill file, which is contained within the ``Pacakge.results`` property, is automatically unpacked whenever getting ``Package.results`` or getting a non-existing attribute. ``Pacakge.results`` is henceforth replaced with the ``plams.Results`` instance itself and all of its non-magic/non-private methods are added to the ``Pacakge`` as instance variables.
For example:
```
>>> from qmflows.packages.SCM import ADF_Result

>>> result = ADF_Result(...)
>>> print(result.results)
<scm.plams.interfaces.adfsuite.adf.ADFResults object at 0x11cc21588>

>>> print(result.get_energy)  # ``result.get_energy`` is a shortcut for ``result.results.get_energy`` 
<bound method ADFResults.get_energy of <scm.plams.interfaces.adfsuite.adf.ADFResults object at 0x11cc21588>>

```
* Issue a warning when accessing  ``Package.results`` yields error an encountered.
* Added typehints to the  ``qmflows.packages`` modules.

Minor
-----
* Updated ``.gitignore`` with ``".spyproject/"``.
* Exchanged all use of ``"/"`` for ``os.sep`` or ``os.path.join()``, improving compatibility with Windows.
* Ensure that ``Package`` and all its sub classes can handle file-like objects.
* Improved the usage of f-strings.
* Implemented a ``Package.__repr__()`` method.
* Generalized the ``Package.__deepcopy__()`` so it'll also work on all its subclasses.
* Removed empty ``Package.prerun()`` and ``Package.postrun()`` methods from ``Package`` subclasses; these (empty) methods are now already defined in the superclass.
* ``find_file_pattern()`` now always returns an iterator; changed ``parse_output_warnings()`` to accommodate this change.
* Cleaned up a number of docstrings
* Made ``Package`` a proper abstract base class; ``Package.handle_special_keywords()`` and ``Package.run_job()`` are now abstract methods.


