### PR TITLE
Added the prm_to_df() function

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -195,7 +195,8 @@ intersphinx_mapping = {
     'python': ('https://docs.python.org/', None),
     'plams': ('https://www.scm.com/doc/plams/', None),
     'noodles': ('https://noodles.readthedocs.io/en/latest/', None),
-    'rdkit': ('https://www.rdkit.org/docs/', None)
+    'rdkit': ('https://www.rdkit.org/docs/', None),
+    'pandas': ('https://pandas.pydata.org/pandas-docs/stable/', None)
 }
 
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -195,8 +195,7 @@ intersphinx_mapping = {
     'python': ('https://docs.python.org/', None),
     'plams': ('https://www.scm.com/doc/plams/', None),
     'noodles': ('https://noodles.readthedocs.io/en/latest/', None),
-    'rdkit': ('https://www.rdkit.org/docs/', None),
-    'pandas': ('https://pandas.pydata.org/pandas-docs/stable/', None)
+    'rdkit': ('https://www.rdkit.org/docs/', None)
 }
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 sphinx>=2.1
+plams@git+https://github.com/SCM-NV/PLAMS@master

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,8 @@ setup(
               "qmflows.parsers",
               "qmflows.templates"],
     package_data={
-        "qmflows": ['data/dictionaries/*yaml']
+        "qmflows": ['data/dictionaries/*yaml',
+                    'py.typed']
     },
     classifiers=[
         'Intended Audience :: Science/Research',

--- a/setup.py
+++ b/setup.py
@@ -36,8 +36,7 @@ setup(
               "qmflows.parsers",
               "qmflows.templates"],
     package_data={
-        "qmflows": ['data/dictionaries/*yaml',
-                    'py.typed']
+        "qmflows": ['data/dictionaries/*yaml']
     },
     classifiers=[
         'Intended Audience :: Science/Research',

--- a/test/test_cp2k_utils.py
+++ b/test/test_cp2k_utils.py
@@ -9,7 +9,7 @@ from assertionlib import assertion
 from qmflows import Settings
 from qmflows.cp2k_utils import (CP2K_KEYS_ALIAS, LengthError, _construct_df,
                                 _get_key_path, _parse_unit, _validate_unit,
-                                map_psf_atoms, set_prm)
+                                map_psf_atoms, set_prm, prm_to_df)
 from qmflows.test_utils import PATH_MOLECULES
 
 PSF_STR = """
@@ -194,3 +194,29 @@ def test_set_prm() -> None:
     assertion.eq(s2, ref)
     assertion.eq(s3, ref)
     assertion.eq(s4, ref)
+
+
+def test_prm_to_df() -> None:
+    """Tests for :func:`prm_to_df`."""
+    s = Settings()
+    s.lennard_jones = {
+        'param': ('epsilon', 'sigma'),
+        'unit': ('kcalmol', 'angstrom'),
+        'Cs': (1, 1),
+        'Cd': (2, 2),
+        'O': (3, 3),
+        'H': (4, 4)
+    }
+
+    ref = {'param': {'epsilon': 'epsilon', 'sigma': 'sigma'},
+           'unit': {'epsilon': 'kcalmol', 'sigma': 'angstrom'},
+           'Cs': {'epsilon': 1.0, 'sigma': 1.0},
+           'Cd': {'epsilon': 2.0, 'sigma': 2.0},
+           'O': {'epsilon': 3.0, 'sigma': 3.0},
+           'H': {'epsilon': 4.0, 'sigma': 4.0}}
+    prm_to_df(s)
+    assertion.eq(s['lennard_jones'].to_dict(), ref)
+
+    # The 'param' key is missing
+    s2 = {'lennard-jones': {'Cs': (1, 2)}}
+    assertion.assert_(prm_to_df, s2, exception=KeyError)


### PR DESCRIPTION
* Marked QMFlows as a typed package (see [PEP 561](https://www.python.org/dev/peps/pep-0561/#id5)).
* Added the PLAMS repository on GitHub to the ``requirements.txt`` file. This should prevent readthedocs from using the outdated PyPi repository.
* Added the ``prm_to_df()`` function in ``qfmlows.cp2k_utils``: Traverse the passed CP2K settings and convert all forcefield parameter blocks into DataFrames.