### PR TITLE
Added Serializers for pandas

### DIFF
--- a/src/qmflows/packages/cp2k_mm.py
+++ b/src/qmflows/packages/cp2k_mm.py
@@ -126,8 +126,9 @@ class CP2KMM(CP2K):
         # Absolute path to the .dill file
         dill_path = join(job.path, f'{job.name}.dill')
 
-        return cls.result_type(cp2k_settings, mol, job_name, r.job.path, dill_path,
-                               work_dir=work_dir, status=job.status, warnings=warnings)
+        return cls.result_type(cp2k_settings, mol, job_name, dill_path=dill_path,
+                               plams_dir=r.job.path, work_dir=work_dir,
+                               status=job.status, warnings=warnings)
 
     @classmethod
     def handle_special_keywords(cls, settings: Settings, key: str,

--- a/src/qmflows/packages/serializer.py
+++ b/src/qmflows/packages/serializer.py
@@ -1,0 +1,77 @@
+"""Various serialisers used in QMFlows."""
+
+import base64
+from typing import Type, TypeVar, Callable, Any, Dict, Mapping, TYPE_CHECKING
+
+from noodles.serial import Serialiser
+
+if TYPE_CHECKING:
+    from ..settings import Settings
+    from scm.plams import Molecule
+    from rdkit.Chem import Mol
+    from pandas.core.generic import NDFrame
+    from pandas import DataFrame, Series
+else:
+    Settings = 'qmflows.settings.Settings'
+    Molecule = 'scm.plams.mol.molecule.Molecule'
+    Mol = 'rdkit.Chem.rdchem.Mol'
+    NDFrame = 'pandas.core.generic.NDFrame'
+    DataFrame = 'pandas.core.frame.DataFrame'
+    Series = 'pandas.core.series.Series'
+
+__all__ = ['SerMolecule', 'SerMol', 'SerSettings', 'SerNDFrame']
+
+T = TypeVar('T')
+MakeRec = Callable[[T], Dict[str, T]]
+
+
+class SerMolecule(Serialiser):
+    """Based on the Plams molecule this class encode and decode the information related to the molecule using the JSON format."""  # noqa: E501
+
+    def __init__(self) -> None:
+        super().__init__(Molecule)
+
+    def encode(self, obj: Molecule, make_rec: MakeRec) -> Dict[str, T]:
+        return make_rec(obj.as_dict())
+
+    def decode(self, cls: Type[Molecule], data: Mapping) -> Molecule:
+        return cls.from_dict(data)
+
+
+class SerMol(Serialiser):
+    """Based on the RDKit molecule this class encodes and decodes the information related to the molecule using a string."""  # noqa: E501
+
+    def __init__(self) -> None:
+        super().__init__(Mol)
+
+    def encode(self, obj: Mol, make_rec: MakeRec) -> Dict[str, T]:
+        return make_rec(base64.b64encode(obj.ToBinary()).decode('ascii'))
+
+    def decode(self, cls: Type[Mol], data: str) -> Mol:
+        return cls(base64.b64decode(data.encode('ascii')))
+
+
+class SerSettings(Serialiser):
+    """Class to encode and decode the :class:`~qmflows.Settings` class using its internal dictionary structure."""  # noqa: E501
+
+    def __init__(self) -> None:
+        super().__init__(Settings)
+
+    def encode(self, obj: Settings, make_rec: MakeRec) -> Dict[str, T]:
+        return make_rec(obj.as_dict())
+
+    def decode(self, cls: Type[Settings], data: Mapping) -> Settings:
+        return cls(data)
+
+
+class SerNDFrame(Serialiser):
+    """Class to encode and decode the :class:`pandas.Series` and :class:`pandas.DataFrame` instances."""  # noqa: E501
+
+    def __init__(self, name: Any = NDFrame):
+        super().__init__(name)
+
+    def encode(self, obj: NDFrame, make_rec: MakeRec) -> Dict[str, T]:
+        return make_rec(obj.to_dict())
+
+    def decode(self, cls: Type[NDFrame], data: Mapping) -> NDFrame:
+        return cls(data)

--- a/src/qmflows/packages/serializer.py
+++ b/src/qmflows/packages/serializer.py
@@ -11,7 +11,8 @@ if TYPE_CHECKING:
     from rdkit.Chem import Mol
     from pandas.core.generic import NDFrame
     from pandas import DataFrame, Series
-else:
+
+else:  # Don't bother importing all this stuff when not type checking
     Settings = 'qmflows.settings.Settings'
     Molecule = 'scm.plams.mol.molecule.Molecule'
     Mol = 'rdkit.Chem.rdchem.Mol'
@@ -22,7 +23,9 @@ else:
 __all__ = ['SerMolecule', 'SerMol', 'SerSettings', 'SerNDFrame']
 
 T = TypeVar('T')
-MakeRec = Callable[[T], Dict[str, T]]
+
+ReturnDict = Dict[str, T]  # This should technically be a :class:`typing.TypedDict`
+MakeRec = Callable[[T], ReturnDict]
 
 
 class SerMolecule(Serialiser):
@@ -31,7 +34,7 @@ class SerMolecule(Serialiser):
     def __init__(self) -> None:
         super().__init__(Molecule)
 
-    def encode(self, obj: Molecule, make_rec: MakeRec) -> Dict[str, T]:
+    def encode(self, obj: Molecule, make_rec: MakeRec) -> ReturnDict:
         return make_rec(obj.as_dict())
 
     def decode(self, cls: Type[Molecule], data: Mapping) -> Molecule:
@@ -44,7 +47,7 @@ class SerMol(Serialiser):
     def __init__(self) -> None:
         super().__init__(Mol)
 
-    def encode(self, obj: Mol, make_rec: MakeRec) -> Dict[str, T]:
+    def encode(self, obj: Mol, make_rec: MakeRec) -> ReturnDict:
         return make_rec(base64.b64encode(obj.ToBinary()).decode('ascii'))
 
     def decode(self, cls: Type[Mol], data: str) -> Mol:
@@ -57,7 +60,7 @@ class SerSettings(Serialiser):
     def __init__(self) -> None:
         super().__init__(Settings)
 
-    def encode(self, obj: Settings, make_rec: MakeRec) -> Dict[str, T]:
+    def encode(self, obj: Settings, make_rec: MakeRec) -> ReturnDict:
         return make_rec(obj.as_dict())
 
     def decode(self, cls: Type[Settings], data: Mapping) -> Settings:
@@ -67,10 +70,10 @@ class SerSettings(Serialiser):
 class SerNDFrame(Serialiser):
     """Class to encode and decode the :class:`pandas.Series` and :class:`pandas.DataFrame` instances."""  # noqa: E501
 
-    def __init__(self, name: Any = NDFrame):
+    def __init__(self, name: Any = NDFrame) -> None:
         super().__init__(name)
 
-    def encode(self, obj: NDFrame, make_rec: MakeRec) -> Dict[str, T]:
+    def encode(self, obj: NDFrame, make_rec: MakeRec) -> ReturnDict:
         return make_rec(obj.to_dict())
 
     def decode(self, cls: Type[NDFrame], data: Mapping) -> NDFrame:


### PR DESCRIPTION
* Moved all ``Serializer`` subclasses to their own module.
* Added type-hints to the ``Serializer`` subclasses.
* Added a ``Serializer`` subclass for ``pandas.DataFrame`` and ``pandas.Series``.
* FIxed a bug where two positional arguments in ``CP2K_MM.run_job()`` were swapped around.
