### PR TITLE
Remove the `path_t21` parameter from `ADF_Result.__init__()`

### DIFF
--- a/src/qmflows/packages/SCM.py
+++ b/src/qmflows/packages/SCM.py
@@ -4,7 +4,7 @@ __all__ = ['ADF_Result', 'DFTB_Result', 'adf', 'dftb']
 
 import os
 import struct
-from os.path import join
+from os.path import join, basename, normpath
 from typing import Any, ClassVar, Optional, Union, Type
 from warnings import warn
 
@@ -102,7 +102,6 @@ class ADF_Result(Result):
     def __init__(self, settings: Optional[Settings],
                  molecule: Optional[plams.Molecule],
                  job_name: str,
-                 path_t21: Union[str, os.PathLike],
                  dill_path: Union[None, str, os.PathLike] = None,
                  plams_dir: Union[None, str, os.PathLike] = None,
                  work_dir: Union[None, str, os.PathLike] = None,
@@ -113,7 +112,12 @@ class ADF_Result(Result):
                          plams_dir=plams_dir, status=status, warnings=warnings)
 
         # Create a KF reader instance
-        self.kf = plams.KFFile(path_t21)
+        if plams_dir is not None:
+            name_t21 = basename(normpath(plams_dir))
+            path_t21 = join(plams_dir, f'{name_t21}.t21')
+            self.kf = plams.KFFile(path_t21)
+        else:
+            self.kf = None
 
     def get_property_kf(self, prop: str, section: Optional[str] = None) -> Any:
         """Interface for :meth:`plams.KFFile.read()<scm.plams.tools.kftools.KFFile.read>`."""
@@ -213,11 +217,6 @@ class ADF(Package):
         job = plams.ADFJob(name=job_name, molecule=mol,
                            settings=adf_settings)
         result = job.run()
-        # Path to the tape 21 file
-        path_t21 = result._kf.path
-
-        # Relative path to the CWD
-        relative_path_t21 = join(*str(path_t21).split(os.sep)[-3:])
 
         # Relative job path
         relative_plams_path = join(*str(result.job.path).split(os.sep)[-2:])
@@ -226,7 +225,7 @@ class ADF(Package):
         dill_path = join(job.path, f'{job.name}.dill')
 
         adf_result = cls.result_type(
-            adf_settings, mol, result.job.name, relative_path_t21, dill_path,
+            adf_settings, mol, result.job.name, dill_path,
             plams_dir=relative_plams_path, status=job.status)
 
         return adf_result

--- a/src/qmflows/packages/SCM.py
+++ b/src/qmflows/packages/SCM.py
@@ -112,9 +112,9 @@ class ADF_Result(Result):
                          plams_dir=plams_dir, status=status, warnings=warnings)
 
         # Create a KF reader instance
-        if workdir is not None:
+        if work_dir is not None:
             # The t21 path has to be absolute: use workdir instead of plams_dir
-            name_t21 = basename(normpath(workdir))
+            name_t21 = basename(normpath(work_dir))
             path_t21 = join(plams_dir, f'{name_t21}.t21')
             self.kf = plams.KFFile(path_t21)
         else:
@@ -228,7 +228,7 @@ class ADF(Package):
         adf_result = cls.result_type(
             adf_settings, mol, result.job.name, dill_path,
             plams_dir=relative_plams_path,
-            workdir=result.job.path, status=job.status)
+            work_dir=result.job.path, status=job.status)
 
         return adf_result
 

--- a/src/qmflows/packages/SCM.py
+++ b/src/qmflows/packages/SCM.py
@@ -112,8 +112,9 @@ class ADF_Result(Result):
                          plams_dir=plams_dir, status=status, warnings=warnings)
 
         # Create a KF reader instance
-        if plams_dir is not None:
-            name_t21 = basename(normpath(plams_dir))
+        if workdir is not None:
+            # The t21 path has to be absolute: use workdir instead of plams_dir
+            name_t21 = basename(normpath(workdir))
             path_t21 = join(plams_dir, f'{name_t21}.t21')
             self.kf = plams.KFFile(path_t21)
         else:
@@ -226,7 +227,8 @@ class ADF(Package):
 
         adf_result = cls.result_type(
             adf_settings, mol, result.job.name, dill_path,
-            plams_dir=relative_plams_path, status=job.status)
+            plams_dir=relative_plams_path,
+            workdir=result.job.path, status=job.status)
 
         return adf_result
 

--- a/test/test_adf_mock.py
+++ b/test/test_adf_mock.py
@@ -20,7 +20,7 @@ def test_adf_mock(mocker):
     dill_path = WORKDIR / jobname / "ADFjob.dill"
     plams_dir = WORKDIR / jobname
     run_mocked.return_value = ADF_Result(templates.geometry, mol, jobname,
-                                         dill_path=dill_path, workdir=plams_dir,
+                                         dill_path=dill_path, work_dir=plams_dir,
                                          plams_dir=plams_dir)
     rs = run_mocked(job)
     assertion.isfinite(rs.energy)

--- a/test/test_adf_mock.py
+++ b/test/test_adf_mock.py
@@ -20,7 +20,8 @@ def test_adf_mock(mocker):
     dill_path = WORKDIR / jobname / "ADFjob.dill"
     plams_dir = WORKDIR / jobname
     run_mocked.return_value = ADF_Result(templates.geometry, mol, jobname,
-                                         dill_path=dill_path, plams_dir=plams_dir)
+                                         dill_path=dill_path, workdir=plams_dir,
+                                         plams_dir=plams_dir)
     rs = run_mocked(job)
     assertion.isfinite(rs.energy)
     assertion.isfinite(rs.homo)

--- a/test/test_adf_mock.py
+++ b/test/test_adf_mock.py
@@ -19,8 +19,7 @@ def test_adf_mock(mocker):
     jobname = "ADFjob"
     dill_path = WORKDIR / jobname / "ADFjob.dill"
     plams_dir = WORKDIR / jobname
-    path_t21 = WORKDIR / jobname / "ADFjob.t21"
-    run_mocked.return_value = ADF_Result(templates.geometry, mol, jobname, path_t21,
+    run_mocked.return_value = ADF_Result(templates.geometry, mol, jobname,
                                          dill_path=dill_path, plams_dir=plams_dir)
     rs = run_mocked(job)
     assertion.isfinite(rs.energy)


### PR DESCRIPTION
The ``ADF_Result`` currently takes an extra parameter (compared to all other ``Result`` classes) by the name of ``path_t21``. This extra argument is not accounted from whenever a job crashes, thus causing problems in the lines of code below (_i.e._ it raises a ``TypeError: __init__() missing 1 required positional argument: 'path_t21'``). https://github.com/SCM-NV/qmflows/blob/5e8a2259b3bbcf532099373768fe07537377a415/src/qmflows/packages/packages.py#L346-L369

The herein implemented solution does the following two things:
* Remove the ``path_t21`` parameter from ``ADF_Result.__init__()``.
* Internally construct the tape21 path using the ``plams_dir`` parameter, similar to how ``DFTB_Result.__init__()`` does it.