### PR TITLE
Added the geometry property to `ADF_Result` and `DFTB_Result`

### DIFF
--- a/src/qmflows/packages/SCM.py
+++ b/src/qmflows/packages/SCM.py
@@ -132,6 +132,10 @@ class ADF_Result(Result):
         m.from_array(coords)
         return m
 
+    @property
+    def geometry(self) -> Optional[plams.Molecule]:
+        return self.molecule
+
 
 class DFTB_Result(Result):
     """Class providing access to PLAMS DFTBJob result results."""
@@ -168,6 +172,10 @@ class DFTB_Result(Result):
         coords = np.array([coords[i: i + 3] for i in range(0, len(coords), 3)])
         m.from_array(coords)
         return m
+
+    @property
+    def geometry(self) -> Optional[plams.Molecule]:
+        return self.molecule
 
 
 class ADF(Package):


### PR DESCRIPTION
Adds the ``ADF_Result.geometry`` and ``DFTB_Result.geometry`` properties, thus allowing one to extract optimized geometries via the same keyword as ``CP2K_Result`` (see below). https://github.com/SCM-NV/qmflows/blob/b979d92a1d46ff188d90d05e71e66f86649a0091/src/qmflows/data/dictionaries/propertiesCP2K.yaml#L12-L15
