### PR TITLE
Fix GitHub Actions test

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -50,7 +50,7 @@ setup(
                       'plams@git+https://github.com/SCM-NV/PLAMS@a5696ce62c09153a9fa67b2b03a750913e1d0924',
                       'pyparsing', 'pyyaml>=5.1', 'filelock'],
     extras_require={
-        'test': ['assertionlib', 'mypy', 'pytest>=5.4', 'pytest-cov',
+        'test': ['assertionlib>=2.2.0', 'mypy', 'pytest>=5.4', 'pytest-cov',
                  'pytest-mock', 'pytest-pycodestyle', 'pytest-pydocstyle>=2.1',
                  'typing_extensions'],
         'doc': ['sphinx>=2.1', 'sphinx-autodoc-typehints', 'sphinx_rtd_theme', 'nbsphinx']

--- a/test/test_cp2k_mock.py
+++ b/test/test_cp2k_mock.py
@@ -54,6 +54,7 @@ def test_cp2k_singlepoint_mock(mocker: MockFixture):
     s.specific.cp2k.force_eval.dft.print.mo.mo_index_range = "7 46"
     s.specific.cp2k.force_eval.dft.scf.added_mos = 20
 
+    # Construct a result objects
     job = cp2k(s, ETHYLENE)
     jobname = "cp2k_job"
     run_mocked = mock_runner(mocker, jobname)

--- a/test/test_cp2k_mock.py
+++ b/test/test_cp2k_mock.py
@@ -65,7 +65,7 @@ def test_cp2k_singlepoint_mock(mocker: MockFixture):
 
     # Molecular orbitals
     orbs = rs.orbitals
-    assertion.isfinite(np.sum(orbs.eigenVals))  # eigenvalues
+    assertion.assert_(np.isfinite, orbs.eigenVals, post_process=np.all)  # eigenvalues
     assertion.shape_eq(orbs.coeffs, (46, 40))
 
 


### PR DESCRIPTION
For some reason the GitHub actions tests are failing for Python 3.8 ([ref](https://github.com/SCM-NV/qmflows/runs/720617083?check_suite_focus=true)) after https://github.com/SCM-NV/qmflows/pull/194 and https://github.com/SCM-NV/qmflows/pull/195. Note that they're working fine on travis.

Based on the following piece of code it seems that the orbital eigenvalues (``orbs.eigenVals``) are either set to ``nan`` or contain a ``nan`` value somewhere. https://github.com/SCM-NV/qmflows/blob/4be2b847aeaf814bddcd61ad51f66e84ba618f7b/test/test_cp2k_mock.py#L58-L69

TODO
------
- [ ] Attempt to figure out what's going on.
