### PR TITLE
Use `InitRestart` when running QMFlows jobs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# Version 0.10.1 (09/06/2020)
+
+# Changed
+  * Exposed ``InitRestart`` to the main QMFlows ``__init__.py`` file.
+  * Exchanged ``plams.init()`` / ``plams.finish()`` for ``qmflows.InitRestart`` in the ``qmflows.run()`` function.
+  * Store the ``cache.db`` file in the PLAMS working directory.
+
 
 # Version 0.10.0 (XX/03/2020)
 

--- a/src/qmflows/__init__.py
+++ b/src/qmflows/__init__.py
@@ -4,6 +4,8 @@ from .__version__ import __version__
 
 from .logger import logger
 
+from .utils import InitRestart
+
 from .components import (
     Angle, Dihedral, Distance,
     find_first_job, select_max, select_min)
@@ -19,6 +21,7 @@ from .examples import (example_H2O2_TS, example_freqs, example_generic_constrain
 __all__ = [
     '__version__',
     'logger',
+    'InitRestart',
     'Angle', 'Dihedral', 'Distance', 'Settings',
     'adf', 'cp2k', 'cp2k_mm', 'dftb', 'orca', 'run', 'PackageWrapper',
     'example_H2O2_TS', 'example_freqs', 'example_generic_constraints',

--- a/src/qmflows/__version__.py
+++ b/src/qmflows/__version__.py
@@ -1,1 +1,3 @@
-__version__ = "0.10.0"
+"""The QMFlows version."""
+
+__version__ = "0.10.1"


### PR DESCRIPTION
Implementation of https://github.com/SCM-NV/qmflows/issues/197:
* Exposed ``InitRestart`` to the main QMFlows ``__init__.py`` file.
* Exchanged ``plams.init()`` / ``plams.finish()`` for ``qmflows.InitRestart`` in the ``qmflows.run()`` function.
* Store the ``cache.db`` file in the PLAMS working directory.