### PR TITLE
allow other cp2k executables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,15 @@
+# Version 0.10.2
+
+## New
+  * Allow other cp2k executable: ``cp2k.sopt``, ``cp2k.psmp``, etc.
+
+
 # Version 0.10.1 (09/06/2020)
 
-# Changed
+## Changed
   * Exposed ``InitRestart`` to the main QMFlows ``__init__.py`` file.
   * Exchanged ``plams.init()`` / ``plams.finish()`` for ``qmflows.InitRestart`` in the ``qmflows.run()`` function.
   * Store the ``cache.db`` file in the PLAMS working directory.
-
 
 # Version 0.10.0 (XX/03/2020)
 

--- a/src/qmflows/__version__.py
+++ b/src/qmflows/__version__.py
@@ -1,3 +1,3 @@
 """The QMFlows version."""
 
-__version__ = "0.10.1"
+__version__ = "0.10.2"

--- a/src/qmflows/packages/cp2k_package.py
+++ b/src/qmflows/packages/cp2k_package.py
@@ -77,6 +77,7 @@ class CP2K(Package):
         # Input modifications
         cp2k_settings = Settings()
         cp2k_settings.input = settings.specific.cp2k
+        cp2k_settings.executable = settings.get("executable", "cp2k.popt")
 
         # Create a Plams job
         job = plams.interfaces.thirdparty.cp2k.Cp2kJob(
@@ -174,9 +175,13 @@ class CP2K(Package):
             """Set the keyword for periodic calculations."""
             s.specific.cp2k.force_eval.subsys.cell.periodic = value
 
+        def ignore_keyword(s: Settings, value: Any, mol: plams.Molecule, key: str) -> None:
+            pass
+
         funs = {'cell_parameters': write_cell_parameters,
                 'cell_angles': write_cell_angles,
-                'periodic': write_periodic}
+                'periodic': write_periodic,
+                'executable': ignore_keyword}
 
         # Function that handles the special keyword
         f = funs.get(key)


### PR DESCRIPTION
## New
  * Allow other cp2k executable: ``cp2k.sopt``, ``cp2k.psmp``, etc.

