### PR TITLE
Run pydocstyle and pycodestyle over src/

### DIFF
--- a/.github/workflows/pythonapp.yml
+++ b/.github/workflows/pythonapp.yml
@@ -8,6 +8,7 @@ jobs:
     runs-on: ubuntu-latest
 
     strategy:
+      fail-fast: false
       matrix:
         version: [3.7, 3.8]
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,7 @@ install:
 
 script:
   # Run the unitary tests excluding the expensive computations
-  - pytest -m "not (slow or long)" --cov=qmflows test
+  - pytest -m "not (slow or long)"
   - coverage xml && coverage report -m
 
 branches:

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,8 @@
+coverage:
+  status:
+    project:
+      default:
+        target: 80
+    patch:
+      default:
+        target: 0

--- a/setup.cfg
+++ b/setup.cfg
@@ -13,7 +13,7 @@ source = src
 max-line-length = 100
 
 [tool:pytest]
-testpaths = test
+testpaths = qmflows test
 addopts = --pycodestyle --pydocstyle --tb=short --cov --cov-report xml --cov-report term --cov-report html
 markers = slow: A marker for slow tests requiring external quantum-chemical packages.
 
@@ -23,3 +23,8 @@ source-dir = docs
 build-dir = docs/_build
 all_files = 1
 builder = html
+
+[pydocstyle]
+convention = numpy
+add-ignore = D401  # First line should be in imperative mood
+ignore-decorators = overload

--- a/setup.cfg
+++ b/setup.cfg
@@ -13,7 +13,7 @@ source = src
 max-line-length = 100
 
 [tool:pytest]
-testpaths = qmflows test
+testpaths = src test
 addopts = --pycodestyle --pydocstyle --tb=short --cov --cov-report xml --cov-report term --cov-report html
 markers = slow: A marker for slow tests requiring external quantum-chemical packages.
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -10,6 +10,8 @@ branch = True
 source = src
 
 [pycodestyle]
+ignore = E302,E301,W504  # E302 & E301 due pycodestyle's awful support for @overload
+select = W503  # W503 looks better than W504
 max-line-length = 100
 
 [tool:pytest]

--- a/src/qmflows/components/reactivity.py
+++ b/src/qmflows/components/reactivity.py
@@ -52,11 +52,11 @@ class Coordinate:
         return self.fun(conf, *xs)
 
     @overload
-    def get_settings(self, value: Any, mol: None) -> Settings: ...
-
+    def get_settings(self, value: Any, mol: None) -> Settings:
+        ...
     @overload
-    def get_settings(self, value: None, mol: MolType) -> Settings: ...
-
+    def get_settings(self, value: None, mol: MolType) -> Settings:
+        ...
     def get_settings(self, value=None, mol=None):
         """Map a :class:`str` representation of :attr:`Coordinate.atoms` to *value*."""
         s = Settings()

--- a/src/qmflows/components/reactivity.py
+++ b/src/qmflows/components/reactivity.py
@@ -1,3 +1,5 @@
+"""A module containing the :class:`Coordinate` baseclass and its subclasses."""
+
 from typing import Callable, Any, ClassVar, Tuple, overload
 
 import scm.plams.interfaces.molecule.rdkit as molkit

--- a/src/qmflows/cp2k_utils.py
+++ b/src/qmflows/cp2k_utils.py
@@ -287,11 +287,13 @@ def set_prm(settings: Settings, key: Union[str, Tuple[str, ...]],
 @overload
 def set_prm_values(prm_key: str, prm_map: MappingScalar,
                    atom_map: MutableMapping[Optional[str], int],
-                   settings_base: List[Settings], atom_key: str) -> None: ...
-@overload
+                   settings_base: List[Settings], atom_key: str) -> None:
+    ...
+@overload  # noqa: E302
 def set_prm_values(prm_key: Sequence[str], prm_map: MappingSequence,
                    atom_map: MutableMapping[Optional[str], int],
-                   settings_base: List[Settings], atom_key: str) -> None: ...
+                   settings_base: List[Settings], atom_key: str) -> None:
+    ...
 def set_prm_values(prm_key, prm_map, atom_map,
                    settings_base, atom_key) -> None:  # noqa: E302
     """Assign the actual values specified in :func:`set_prm`.
@@ -366,9 +368,11 @@ def _(unit: Optional[str]) -> List[str]:
 
 
 @overload
-def _construct_df(columns: Sequence[str], prm_map: MappingSequence) -> pd.DataFrame: ...
-@overload
-def _construct_df(columns: str, prm_map: MappingScalar) -> pd.DataFrame: ...
+def _construct_df(columns: Sequence[str], prm_map: MappingSequence) -> pd.DataFrame:
+    ...
+@overload  # noqa: E302
+def _construct_df(columns: str, prm_map: MappingScalar) -> pd.DataFrame:
+    ...
 def _construct_df(columns, prm_map) -> pd.DataFrame:  # noqa: E302
     """Convert *prm_map* into a :class:`pandas.DataFrame` of strings with *columns* as columns.
 

--- a/src/qmflows/data/__init__.py
+++ b/src/qmflows/data/__init__.py
@@ -1,0 +1,1 @@
+"""Various non-`.py` files used throughout QMFlows."""

--- a/src/qmflows/data/dictionaries/__init__.py
+++ b/src/qmflows/data/dictionaries/__init__.py
@@ -1,0 +1,1 @@
+"""Various :class:`~qmflows.packages.packages.Package`-related .yaml files."""

--- a/src/qmflows/examples/Conditional_workflows/__init__.py
+++ b/src/qmflows/examples/Conditional_workflows/__init__.py
@@ -1,3 +1,5 @@
+"""Various examples involving conditional workflows."""
+
 from .calc_freqs import example_freqs
 
 __all__ = ['example_freqs']

--- a/src/qmflows/examples/Conditional_workflows/calc_freqs.py
+++ b/src/qmflows/examples/Conditional_workflows/calc_freqs.py
@@ -1,3 +1,5 @@
+"""A module with examples related to frequency calculations."""
+
 __all__ = ['example_freqs']
 
 from noodles import gather
@@ -6,16 +8,14 @@ import scm.plams.interfaces.molecule.rdkit as molkit
 
 
 def is_successful(result):
-    """
-    Define the condition for a successful calculation
-    """
-    return result.status not in ["failed", "crashed"]
+    """Define the condition for a successful calculation."""
+    return result.status not in {"failed", "crashed"}
 
 
 def example_freqs():
-    """
-    This examples illustrates the possibility to use different packages interchangeably.
-    Analytical frequencies are not available for B3LYP in ADF
+    """An examples which illustrates the possibility using different packages interchangeably.
+
+    Analytical frequencies are not available for B3LYP in ADF.
     This workflow captures the resulting error and submits the same job to ORCA.
     """
     # Generate water molecule

--- a/src/qmflows/examples/Constrained_and_TS_optimizations/H2O2_TS.py
+++ b/src/qmflows/examples/Constrained_and_TS_optimizations/H2O2_TS.py
@@ -1,3 +1,5 @@
+"""A module holding the :func:`example_H2O2_TS` example function."""
+
 __all__ = ['example_H2O2_TS']
 
 import scm.plams.interfaces.molecule.rdkit as molkit
@@ -5,13 +7,11 @@ from qmflows import (orca, dftb, templates, Dihedral, run, Settings, logger)
 
 
 def example_H2O2_TS():
-    """
-    This example generates an approximate TS for rotation in hydrogen peroxide
-    using DFTB, and performs a full TS optimization in Orca.
-    It illustrates using a hessian from one package, DFTB in this case,
-    to initialize a TS optimization in another, i.e. Orca in this case
-    """
+    """Am example which generates an approximate TS for rotation in hydrogen peroxide using DFTB, and performs a full TS optimization in Orca.
 
+    It illustrates using a hessian from one package, DFTB in this case,
+    to initialize a TS optimization in another, *i.e.* Orca in this case
+    """  # noqa: E501
     # Generate hydrogen peroxide molecule
     h2o2 = molkit.from_smarts('[H]OO[H]')
 

--- a/src/qmflows/examples/Constrained_and_TS_optimizations/__init__.py
+++ b/src/qmflows/examples/Constrained_and_TS_optimizations/__init__.py
@@ -1,3 +1,5 @@
+"""Various examples related to constrained geometry optimizations."""
+
 from .generic_constraints import example_generic_constraints
 from .H2O2_TS import example_H2O2_TS
 from .partial_geometry_opt import example_partial_geometry_opt

--- a/src/qmflows/examples/Constrained_and_TS_optimizations/generic_constraints.py
+++ b/src/qmflows/examples/Constrained_and_TS_optimizations/generic_constraints.py
@@ -1,3 +1,5 @@
+"""An example workflow for generic constrained geometry optimizations."""
+
 __all__ = ['example_generic_constraints']
 
 import scm.plams.interfaces.molecule.rdkit as molkit
@@ -7,10 +9,10 @@ from qmflows import (dftb, adf, orca, run, Settings, templates, logger)
 
 def example_generic_constraints():
     """Run different job with geometric constrains.
-    This examples illustrates that, by using generic keywords, it is possible
-    to call different packages interchangeably with the same Settings
-    """
 
+    This examples illustrates that, by using generic keywords, it is possible
+    to call different packages interchangeably with the same Settings.
+    """
     # build hydrogen fluoride molecule
     hydrogen_fluoride = molkit.from_smiles('F[H]')
 

--- a/src/qmflows/examples/Constrained_and_TS_optimizations/partial_geometry_opt.py
+++ b/src/qmflows/examples/Constrained_and_TS_optimizations/partial_geometry_opt.py
@@ -1,3 +1,5 @@
+"""A module containing the example :func:`example_partial_geometry_opt` function."""
+
 __all__ = ['example_partial_geometry_opt']
 
 import scm.plams.interfaces.molecule.rdkit as molkit
@@ -6,9 +8,7 @@ from qmflows import (adf, run, Settings, templates)
 
 
 def example_partial_geometry_opt():
-    """
-    Performa partial optimization freezing the Hydrogen atoms
-    """
+    """Performa partial optimization freezing the Hydrogen atoms."""
     methanol = molkit.from_smiles('CO')
 
     # optimize only H atoms

--- a/src/qmflows/examples/__init__.py
+++ b/src/qmflows/examples/__init__.py
@@ -1,3 +1,5 @@
+"""Various example workflows for QMFlows."""
+
 from .Conditional_workflows import example_freqs
 from .Constrained_and_TS_optimizations import (
     example_H2O2_TS, example_generic_constraints, example_partial_geometry_opt)

--- a/src/qmflows/packages/SCM.py
+++ b/src/qmflows/packages/SCM.py
@@ -139,6 +139,7 @@ class ADF_Result(Result):
 
     @property
     def geometry(self) -> Optional[plams.Molecule]:
+        """An alias for :attr:`ADF_Result.molecule`."""
         return self.molecule
 
 
@@ -180,6 +181,7 @@ class DFTB_Result(Result):
 
     @property
     def geometry(self) -> Optional[plams.Molecule]:
+        """An alias for :attr:`DFTB_Result.molecule`."""
         return self.molecule
 
 

--- a/src/qmflows/packages/__init__.py
+++ b/src/qmflows/packages/__init__.py
@@ -1,3 +1,5 @@
+"""A set of modules for managing various quantum-chemical packages."""
+
 from .packages import (
     Package, Result, SerMolecule, SerSettings, load_properties,
     run, registry)

--- a/src/qmflows/packages/cp2k_mm.py
+++ b/src/qmflows/packages/cp2k_mm.py
@@ -30,20 +30,20 @@ __all__ = ['cp2k_mm']
 
 
 class CP2KMM_Result(Result):
-    """Class providing access to CP2KMM result."""
+    """A class providing access to CP2KMM result."""
 
     prop_mapping: ClassVar[_Settings] = load_properties('CP2KMM', prefix='properties')
 
 
 class CP2KMM(CP2K):
-    """This class setup the requirement to run a `CP2K Job <https://www.cp2k.org/>`_ for classical forcefield calculations.
+    """A Package subclass for running `CP2K Jobs <https://www.cp2k.org/>`_ for classical forcefield calculations.
 
     It uses plams together with the templates to generate the stucture input
     and also uses Plams to invoke the binary CP2K code.
     This class is not intended to be called directly by the user, instead the
     :data:`cp2k_mm` function should be called.
 
-    """  # noqa
+    """  # noqa: E501
 
     generic_mapping: ClassVar[_Settings] = load_properties('CP2KMM', prefix='generic2')
     result_type: ClassVar[Type[Result]] = CP2KMM_Result

--- a/src/qmflows/packages/cp2k_package.py
+++ b/src/qmflows/packages/cp2k_package.py
@@ -36,7 +36,7 @@ class CP2K_Result(Result):
 
 
 class CP2K(Package):
-    """This class setup the requirement to run a `CP2K Job <https://www.cp2k.org/>`_.
+    """A Package subclass for running `CP2K Jobs <https://www.cp2k.org/>`_.
 
     It uses plams together with the templates to generate the stucture input
     and also uses Plams to invoke the binary CP2K code.

--- a/src/qmflows/packages/orca.py
+++ b/src/qmflows/packages/orca.py
@@ -40,7 +40,7 @@ class ORCA_Result(Result):
 
 
 class ORCA(Package):
-    """This class prepare the input to run a Orca job using both PLAMS and templates.
+    """A class for preparing the input for running a Orca job using both PLAMS and templates.
 
     It also does the manangement of the input/output files resulting
     from running Orca and returns a Results object that containing the methods

--- a/src/qmflows/packages/serializer.py
+++ b/src/qmflows/packages/serializer.py
@@ -24,20 +24,20 @@ __all__ = ['SerMolecule', 'SerMol', 'SerSettings', 'SerNDFrame']
 
 T = TypeVar('T')
 
-ReturnDict = Dict[str, T]  # This should technically be a :class:`typing.TypedDict`
-MakeRec = Callable[[T], ReturnDict]
-
 
 class SerMolecule(Serialiser):
     """Based on the Plams molecule this class encode and decode the information related to the molecule using the JSON format."""  # noqa: E501
 
     def __init__(self) -> None:
+        """Initialize a :class:`SerMolecule` instance."""
         super().__init__(Molecule)
 
-    def encode(self, obj: Molecule, make_rec: MakeRec) -> ReturnDict:
+    def encode(self, obj: Molecule, make_rec: Callable[[T], Dict[str, T]]) -> Dict[str, T]:
+        """Encode the passed PLAMS Molecule."""
         return make_rec(obj.as_dict())
 
     def decode(self, cls: Type[Molecule], data: Mapping) -> Molecule:
+        """Decode the passed data into a PLAMS Molecule."""
         return cls.from_dict(data)
 
 
@@ -45,12 +45,15 @@ class SerMol(Serialiser):
     """Based on the RDKit molecule this class encodes and decodes the information related to the molecule using a string."""  # noqa: E501
 
     def __init__(self) -> None:
+        """Initialize a :class:`SerMol` instance."""
         super().__init__(Mol)
 
-    def encode(self, obj: Mol, make_rec: MakeRec) -> ReturnDict:
+    def encode(self, obj: Mol, make_rec: Callable[[T], Dict[str, T]]) -> Dict[str, T]:
+        """Encode the passed RDKit Mol."""
         return make_rec(base64.b64encode(obj.ToBinary()).decode('ascii'))
 
     def decode(self, cls: Type[Mol], data: str) -> Mol:
+        """Decode the passed data into a RDKit Mol."""
         return cls(base64.b64decode(data.encode('ascii')))
 
 
@@ -58,12 +61,15 @@ class SerSettings(Serialiser):
     """Class to encode and decode the :class:`~qmflows.Settings` class using its internal dictionary structure."""  # noqa: E501
 
     def __init__(self) -> None:
+        """Initialize a :class:`SerSettings` instance."""
         super().__init__(Settings)
 
-    def encode(self, obj: Settings, make_rec: MakeRec) -> ReturnDict:
+    def encode(self, obj: Settings, make_rec: Callable[[T], Dict[str, T]]) -> Dict[str, T]:
+        """Encode the passed PLAMS Settings."""
         return make_rec(obj.as_dict())
 
     def decode(self, cls: Type[Settings], data: Mapping) -> Settings:
+        """Decode the passed data into a PLAMS Settings."""
         return cls(data)
 
 
@@ -71,10 +77,13 @@ class SerNDFrame(Serialiser):
     """Class to encode and decode the :class:`pandas.Series` and :class:`pandas.DataFrame` instances."""  # noqa: E501
 
     def __init__(self, name: Any = NDFrame) -> None:
+        """Initialize a :class:`SerNDFrame` instance."""
         super().__init__(name)
 
-    def encode(self, obj: NDFrame, make_rec: MakeRec) -> ReturnDict:
+    def encode(self, obj: NDFrame, make_rec: Callable[[T], Dict[str, T]]) -> Dict[str, T]:
+        """Encode the passed pandas Series or DataFrame."""
         return make_rec(obj.to_dict())
 
     def decode(self, cls: Type[NDFrame], data: Mapping) -> NDFrame:
+        """Decode the passed data into a pandas Series or DataFrame."""
         return cls(data)

--- a/src/qmflows/parsers/cp2KParser.py
+++ b/src/qmflows/parsers/cp2KParser.py
@@ -143,7 +143,7 @@ def readCp2KCoeff(path: PathLike, nOrbitals: int, nOrbFuns: int) -> InfoMO:
     for i, xs in enumerate(chunks):
         j = 2 * i
         es = xs[1]
-        css = [l[4:] for l in xs[3:]]
+        css = [k[4:] for k in xs[3:]]
         # There is an odd number of MO and this is the last one
         if len(es) == 1:
             eigenVals[-1] = float(es[0])
@@ -183,25 +183,34 @@ orbInfo = natural * 2 + Word(alphas, max=2) + orbitals
 # ====================> Basis File <==========================
 comment = Literal("#") + restOfLine
 
-parseAtomLabel = (Word(srange("[A-Z]"), max=1) +
-                  Optional(Word(srange("[a-z]"), max=1)))
+parseAtomLabel = (
+    Word(srange("[A-Z]"), max=1) +
+    Optional(Word(srange("[a-z]"), max=1))
+)
 
 parserBasisName = Word(alphanums + "-") + Suppress(restOfLine)
 
 parserFormat = OneOrMore(natural + NotAny(FollowedBy(point)))
 
-parserKey = parseAtomLabel.setResultsName("atom") + \
-    parserBasisName.setResultsName("basisName") + \
+parserKey = (
+    parseAtomLabel.setResultsName("atom") +
+    parserBasisName.setResultsName("basisName") +
     Suppress(Literal("1"))
+)
 
 parserBasisData = OneOrMore(floatNumber)
 
-parserBasis = parserKey + parserFormat.setResultsName("format") + \
+parserBasis = (
+    parserKey +
+    parserFormat.setResultsName("format") +
     parserBasisData.setResultsName("coeffs")
+)
 
-
-topParseBasis = OneOrMore(Suppress(comment)) + \
-    OneOrMore(Group(parserBasis + Suppress(Optional(OneOrMore(comment)))))
+topParseBasis = (
+    OneOrMore(Suppress(comment)) +
+    OneOrMore(Group(parserBasis +
+    Suppress(Optional(OneOrMore(comment)))))
+)
 
 
 # ===============================<>====================================
@@ -224,8 +233,8 @@ def read_mos_data_input(path_input: PathLike) -> Tuple2:
 
 def read_cp2k_number_of_orbitals(file_name: PathLike) -> MO_metadata:
     """Look for the line ' Number of molecular orbitals:'."""
-    def fun_split(l: str) -> str:
-        return l.split()[-1]
+    def fun_split(string: str) -> str:
+        return string.split()[-1]
 
     properties = ["Number of occupied orbitals", "Number of molecular orbitals",
                   "Number of orbital functions"]
@@ -291,13 +300,11 @@ ST = TypeVar('ST', bound=Sequence)
 
 
 @overload
-def swapCoeff(n: Literal_[1], rs: ST) -> ST: ...
-
-
+def swapCoeff(n: Literal_[1], rs: ST) -> ST:  # type: ignore
+    ...
 @overload
-def swapCoeff(n: int, rs: ST) -> List[ST]: ...  # type: ignore
-
-
+def swapCoeff(n: int, rs: ST) -> List[ST]:
+    ...
 def swapCoeff(n, rs):
     if n == 1:
         return rs
@@ -387,7 +394,7 @@ QUANTITY_MAPPING: Dict[str, str] = {
 
 QUANTITY_SET: FrozenSet[str] = frozenset({'E', 'ZPE', 'H', 'S', 'G'})
 
-Quantity = Literal_[tuple(QUANTITY_SET)]
+Quantity = Literal_['E', 'ZPE', 'H', 'S', 'G']
 
 
 def get_cp2k_thermo(file_name: PathLike, quantity: Quantity = 'G',

--- a/src/qmflows/settings.py
+++ b/src/qmflows/settings.py
@@ -9,7 +9,7 @@ from scm import plams
 
 
 class Settings(plams.core.settings.Settings, ):
-    """This is a subclass of the :class:`plams.core.settings.Settings`.
+    """A subclass of the :class:`plams.core.settings.Settings`.
 
     The difference with respect to plams' Settings are:
     - settings['a.b'] is equivalent to settings['a']['b'] = settings.a.b
@@ -20,30 +20,26 @@ class Settings(plams.core.settings.Settings, ):
     """
 
     def __getitem__(self, name):
-        """
-        Like plams Settings.__getitem__, but
-        "settings['a.b'] == 'c'" is equivalent to "settings['a']['b'] == 'c'"
-        """
+        """Implement :func:`self[name]<object.__getitem__>`."""
         return dict.__getitem__(self, name)
 
     def __setitem__(self, name, value):
+        """Implement :func:`self[name] = value<object.__setitem__>`.
+
+        Like :meth:`dict.__getitem__` but passed dictionaries are converted
+        into :class:`type(self)<Settings>`.
         """
-        Like plams Settings.__setitem__, but
-        "settings['a.b'] = 'c'" is equivalent to "settings['a']['b'] = 'c'"
-        """
-        cls = type(self)
         if isinstance(value, dict):
+            cls = type(self)
             value = cls(value)
         dict.__setitem__(self, name, value)
 
     def __delitem__(self, name):
-        """
-        Like plams Settings.__setitem__, but
-        "del settings['a.b']" is equivalent to "del settings['a']['b'] = 'c'"
-        """
+        """Implement :func:`del self[name]<object.__delitem__>`."""
         dict.__delitem__(self, name)
 
     def copy(self):
+        """Create a deep(-ish) copy of this instance."""
         cls = type(self)
         ret = cls()
         for name in self:
@@ -54,41 +50,49 @@ class Settings(plams.core.settings.Settings, ):
         return ret
 
     def __deepcopy__(self, _):
+        """Implement :func:`copy.deepcopy(self)<copy.deepcopy>`.
+
+        Serves as an alias for :meth:`Settings.copy`.
+        """
         return self.copy()
 
     def overlay(self, other):
-        """
-        Return new instance of |Settings| that is a copy of this instance
-        updated with *other*.
-        """
+        """Return new instance of |Settings| that is a copy of this instance updated with *other*."""  # noqa: E501
         ret = self.copy()
         ret.update(other)
         return ret
 
     def update(self, other):
-        """
+        """Implement :func:`self.update(other)<dict.update>`.
+
         Like PLAMS update, but:
         __block_replace = True results in removing all existing key value pairs
         in the current node of the settings tree
 
         For example:
 
-        >>> from qmflows import Settings
-        >>> t=Settings()
-        >>> t.input.xc.lda = ""
-        >>> u = Settings()
-        >>> u.input.xc.hybrid = 'b3lyp'
-        >>> print(t.overlay(u))
-        input:
-              xc:
-                 hybrid:     b3lyp
-                 lda:
-        >>> u.input.xc.__block_replace = True
-        >>> print(t.overlay(u))
-        input:
-              xc:
-                 __block_replace:     True
-                 hybrid:     b3lyp
+        .. code:: python
+
+            >>> from qmflows import Settings
+
+            >>> t=Settings()
+            >>> t.input.xc.lda = ""
+
+            >>> u = Settings()
+            >>> u.input.xc.hybrid = 'b3lyp'
+            >>> print(t.overlay(u))
+            input:
+                xc:
+                    hybrid:     b3lyp
+                    lda:
+
+            >>> u.input.xc.__block_replace = True
+            >>> print(t.overlay(u))
+            input:
+                xc:
+                    __block_replace:     True
+                    hybrid:     b3lyp
+
         """
         cls = type(self)
         for name in other:
@@ -132,6 +136,7 @@ class _Settings(Settings):
     """Immutable-ish counterpart of :class:`Settings`."""
 
     def __init__(self, *args, **kwargs):
+        """Initialize an instance."""
         cls = type(self)
         set_item = super().__setitem__
 
@@ -143,6 +148,7 @@ class _Settings(Settings):
                 set_item(k, [cls(i) if isinstance(i, dict) else i for i in v])
 
     def __missing__(self, name: str) -> NoReturn:
+        """Raise a :exc:`TypeError`."""
         raise KeyError(name)
 
     __setitem__ = _unsuported_operation(Settings.__setitem__)

--- a/src/qmflows/settings.py
+++ b/src/qmflows/settings.py
@@ -9,14 +9,13 @@ from scm import plams
 
 
 class Settings(plams.core.settings.Settings, ):
-    """A subclass of :class:`<plams.Settings>scm.plams.core.settings.Settings`.
+    """A subclass of :class:`plams.Settings<scm.plams.core.settings.Settings`>.
 
     The difference with respect to plams' Settings are:
     
     - :code:`settings['a.b']` is equivalent to :code:`settings['a']['b'] = settings.a.b`
-    - in :meth:`update`: :code:`settings.__block_replace = True` results in removal of all
-    existing key value pairs.
-
+    - in :meth:`Settings.update`: :code:`settings.__block_replace = True` results in removal 
+      of all existing key value pairs.
       ``__block_replace`` can be either in the updated settings or in the updating settings object.
     """
 
@@ -71,7 +70,7 @@ class Settings(plams.core.settings.Settings, ):
         """Implement :meth:`self.update(other)<dict.update>`.
 
         Like PLAMS update, but:
-        __block_replace = True results in removing all existing key value pairs
+        :code:`__block_replace = True` results in removing all existing key value pairs
         in the current node of the settings tree
 
         For example:

--- a/src/qmflows/settings.py
+++ b/src/qmflows/settings.py
@@ -9,14 +9,15 @@ from scm import plams
 
 
 class Settings(plams.core.settings.Settings, ):
-    """A subclass of the :class:`plams.core.settings.Settings`.
+    """A subclass of :class:`<plams.Settings>scm.plams.core.settings.Settings`.
 
     The difference with respect to plams' Settings are:
-    - settings['a.b'] is equivalent to settings['a']['b'] = settings.a.b
-    - in update(): settings.__block_replace = True results in removal of all
+    
+    - :code:`settings['a.b']` is equivalent to :code:`settings['a']['b'] = settings.a.b`
+    - in :meth:`update`: :code:`settings.__block_replace = True` results in removal of all
     existing key value pairs.
 
-      __block_replace can be either in the updated settings or in the updating settings object.
+      ``__block_replace`` can be either in the updated settings or in the updating settings object.
     """
 
     def __getitem__(self, name):
@@ -26,7 +27,7 @@ class Settings(plams.core.settings.Settings, ):
     def __setitem__(self, name, value):
         """Implement :meth:`self[name] = value<object.__setitem__>`.
 
-        Like :meth:`dict.__getitem__` but passed dictionaries are converted
+        Like its counterpart in :class:`dict` but passed dictionaries are converted
         into instances of :class:`type(self)<Settings>`.
         """
         if isinstance(value, dict):

--- a/src/qmflows/settings.py
+++ b/src/qmflows/settings.py
@@ -20,14 +20,14 @@ class Settings(plams.core.settings.Settings, ):
     """
 
     def __getitem__(self, name):
-        """Implement :func:`self[name]<object.__getitem__>`."""
+        """Implement :meth:`self[name]<object.__getitem__>`."""
         return dict.__getitem__(self, name)
 
     def __setitem__(self, name, value):
-        """Implement :func:`self[name] = value<object.__setitem__>`.
+        """Implement :meth:`self[name] = value<object.__setitem__>`.
 
         Like :meth:`dict.__getitem__` but passed dictionaries are converted
-        into :class:`type(self)<Settings>`.
+        into instances of :class:`type(self)<Settings>`.
         """
         if isinstance(value, dict):
             cls = type(self)
@@ -35,11 +35,15 @@ class Settings(plams.core.settings.Settings, ):
         dict.__setitem__(self, name, value)
 
     def __delitem__(self, name):
-        """Implement :func:`del self[name]<object.__delitem__>`."""
+        """Implement :meth:`del self[name]<object.__delitem__>`."""
         dict.__delitem__(self, name)
 
     def copy(self):
-        """Create a deep(-ish) copy of this instance."""
+        """Create a deep(-ish) copy of this instance.
+        
+        All nested settings instances embedded within *self* are copied recursively;
+        all other objects set without copying.
+        """
         cls = type(self)
         ret = cls()
         for name in self:
@@ -63,7 +67,7 @@ class Settings(plams.core.settings.Settings, ):
         return ret
 
     def update(self, other):
-        """Implement :func:`self.update(other)<dict.update>`.
+        """Implement :meth:`self.update(other)<dict.update>`.
 
         Like PLAMS update, but:
         __block_replace = True results in removing all existing key value pairs
@@ -148,7 +152,7 @@ class _Settings(Settings):
                 set_item(k, [cls(i) if isinstance(i, dict) else i for i in v])
 
     def __missing__(self, name: str) -> NoReturn:
-        """Raise a :exc:`TypeError`."""
+        """Raise a :exc:`KeyError`."""
         raise KeyError(name)
 
     __setitem__ = _unsuported_operation(Settings.__setitem__)

--- a/src/qmflows/settings.py
+++ b/src/qmflows/settings.py
@@ -9,7 +9,7 @@ from scm import plams
 
 
 class Settings(plams.core.settings.Settings, ):
-    """A subclass of :class:`plams.Settings<scm.plams.core.settings.Settings`>.
+    """A subclass of :class:`plams.Settings<scm.plams.core.settings.Settings>`.
 
     The difference with respect to plams' Settings are:
     

--- a/src/qmflows/templates/__init__.py
+++ b/src/qmflows/templates/__init__.py
@@ -1,3 +1,5 @@
+"""Various Settings templates used throughout QMFlows."""
+
 from .templates import (freq, geometry, singlepoint, ts, md)
 
 __all__ = ['freq', 'geometry', 'singlepoint', 'ts', 'md']


### PR DESCRIPTION
Implementation of https://github.com/SCM-NV/qmflows/issues/202:
- [x] Use `testpaths = src test` in `setup.cfg`.
- [x] Handle the resulting linting-related errors, all which have been hidden up until now.
- [x] Added a codecov yaml file.