### PR TITLE
Cp2k unrestricted

### DIFF
--- a/src/qmflows/parsers/cp2KParser.py
+++ b/src/qmflows/parsers/cp2KParser.py
@@ -353,17 +353,22 @@ def split_unrestricted_log_file(path: PathLike) -> Tuple[Path, Path]:
     """Split the log file into alpha and beta molecular orbitals."""
     root, file_name = os.path.split(path)
     cmd = f'csplit -f coeffs -n 1 {file_name} "/HOMO-LUMO/+2"'
-    subprocess.call(cmd, shell=True, stdout=subprocess.DEVNULL,
-                    stderr=subprocess.DEVNULL, cwd=root)
+    subprocess.check_output(cmd, shell=True, stdout=subprocess.DEVNULL, cwd=root)
 
-    alphas = Path(root, "alphas.log")
-    betas = Path(root, "betas.log")
+    # Check that the files exists
+    predicate = all(Path(f).exists() for f in ('coeffs0', 'coeffs1'))
+    if not predicate:
+        msg = "There is a problem splitting the coefficients in alpha and beta components!"
+        raise RuntimeError(msg)
+
+    alpha_orbitals = Path(root, "alphas.log")
+    beta_orbitals = Path(root, "betas.log")
 
     # Move the new set of coefficients to their corresponding names
-    os.rename(Path(root, 'coeffs0'), alphas)
-    os.rename(Path(root, 'coeffs1'), betas)
+    os.rename(Path(root, 'coeffs0'), alpha_orbitals)
+    os.rename(Path(root, 'coeffs1'), beta_orbitals)
 
-    return alphas, betas
+    return alpha_orbitals, beta_orbitals
 
 
 #: A 2-tuple; output of :func:`readCp2KBasis`.

--- a/src/qmflows/parsers/cp2KParser.py
+++ b/src/qmflows/parsers/cp2KParser.py
@@ -365,12 +365,12 @@ def split_unrestricted_log_file(path: PathLike) -> Tuple[Path, Path]:
     beta_orbitals = Path(root, "betas.log")
 
     # Move the new set of coefficients to their corresponding names
-try:
-    os.rename(Path(root, 'coeffs0'), alpha_orbitals)
-    os.rename(Path(root, 'coeffs1'), beta_orbitals)
-except FileNotFoundError as ex:
-    msg = "There is a problem splitting the coefficients in alpha and beta components!"
-    raise RuntimeError(msg) from ex
+    try:
+        os.rename(Path(root, 'coeffs0'), alpha_orbitals)
+        os.rename(Path(root, 'coeffs1'), beta_orbitals)
+    except FileNotFoundError as ex:
+        msg = "There is a problem splitting the coefficients in alpha and beta components!"
+        raise RuntimeError(msg) from ex
 
     return alpha_orbitals, beta_orbitals
 

--- a/src/qmflows/parsers/cp2KParser.py
+++ b/src/qmflows/parsers/cp2KParser.py
@@ -353,7 +353,7 @@ def split_unrestricted_log_file(path: PathLike) -> Tuple[Path, Path]:
     """Split the log file into alpha and beta molecular orbitals."""
     root, file_name = os.path.split(path)
     cmd = f'csplit -f coeffs -n 1 {file_name} "/HOMO-LUMO/+2"'
-    subprocess.check_output(cmd, shell=True, stdout=subprocess.DEVNULL, cwd=root)
+    subprocess.check_call(cmd, shell=True, stdout=subprocess.DEVNULL, cwd=root)
 
     # Check that the files exists
     predicate = all(Path(f).exists() for f in ('coeffs0', 'coeffs1'))

--- a/src/qmflows/parsers/cp2KParser.py
+++ b/src/qmflows/parsers/cp2KParser.py
@@ -365,8 +365,12 @@ def split_unrestricted_log_file(path: PathLike) -> Tuple[Path, Path]:
     beta_orbitals = Path(root, "betas.log")
 
     # Move the new set of coefficients to their corresponding names
+try:
     os.rename(Path(root, 'coeffs0'), alpha_orbitals)
     os.rename(Path(root, 'coeffs1'), beta_orbitals)
+except FileNotFoundError as ex:
+    msg = "There is a problem splitting the coefficients in alpha and beta components!"
+    raise RuntimeError(msg) from ex
 
     return alpha_orbitals, beta_orbitals
 


### PR DESCRIPTION
use [subprocess.check_call](https://docs.python.org/3.8/library/subprocess.html#subprocess.check_call) instead of [subprocess.check_output](https://docs.python.org/3.8/library/subprocess.html#subprocess.check_output)