### PR TITLE
removed mocker from import

### DIFF
--- a/test/test_adf_mock.py
+++ b/test/test_adf_mock.py
@@ -1,6 +1,6 @@
 """Mock the ADF output."""
 from assertionlib import assertion
-from pytest_mock import mocker
+from pytest_mock import MockFixture
 from scm.plams import Molecule
 
 from qmflows import adf, templates
@@ -10,7 +10,7 @@ from qmflows.test_utils import PATH, PATH_MOLECULES
 WORKDIR = PATH / "output_adf"
 
 
-def test_adf_mock(mocker):
+def test_adf_mock(mocker: MockFixture):
     """Mock the ADF output."""
     mol = Molecule(PATH_MOLECULES / "acetonitrile.xyz")
     job = adf(templates.geometry, mol)

--- a/test/test_cp2k_mm_mock.py
+++ b/test/test_cp2k_mm_mock.py
@@ -5,7 +5,7 @@ import shutil
 
 import numpy as np
 from assertionlib import assertion
-from pytest_mock import mocker, MockFixture
+from pytest_mock import MockFixture
 from scm.plams import Molecule
 
 from qmflows import Settings, cp2k_mm, singlepoint, geometry, freq, md

--- a/test/test_cp2k_mock.py
+++ b/test/test_cp2k_mock.py
@@ -4,7 +4,7 @@ import copy
 import pytest
 import numpy as np
 from assertionlib import assertion
-from pytest_mock import MockFixture, mocker
+from pytest_mock import MockFixture
 from scm.plams import Molecule
 
 from qmflows import cp2k, templates

--- a/test/test_dftb_mock.py
+++ b/test/test_dftb_mock.py
@@ -2,7 +2,7 @@
 import numpy as np
 import scm.plams.interfaces.molecule.rdkit as molkit
 from assertionlib import assertion
-from pytest_mock import mocker
+from pytest_mock import MockFixture
 from scm.plams import Molecule
 
 from qmflows import dftb, templates
@@ -23,7 +23,7 @@ def mock_runner(mocker_instance, jobname: str) -> DFTB_Result:
     return run_mocked
 
 
-def test_dftb_opt_mock(mocker):
+def test_dftb_opt_mock(mocker: MockFixture):
     """Mock a geometry optimization using DFTB."""
     jobname = "dftb_geometry"
     job = dftb(templates.geometry, WATER, job_name=jobname)
@@ -37,7 +37,7 @@ def test_dftb_opt_mock(mocker):
     assertion.isinstance(rs.molecule, Molecule)
 
 
-def test_dftb_freq_mock(mocker):
+def test_dftb_freq_mock(mocker: MockFixture):
     """Mock a geometry optimization using DFTB."""
     jobname = "dftb_freq"
     job = dftb(templates.geometry, WATER, job_name=jobname)

--- a/test/test_mock_operations.py
+++ b/test/test_mock_operations.py
@@ -2,12 +2,15 @@
 import numpy as np
 from assertionlib import assertion
 from noodles import run_single
-from pytest_mock import mocker
+from pytest_mock import MockFixture
+from typing import Any, List, Optional
 
 from qmflows.components.operations import select_max, select_min
 
 
-def generate_mocked_results(mocker, target, instances=10, expected=None):
+def generate_mocked_results(
+        mocker: MockFixture, target: str, instances: int=10,
+        expected: Optional[int]=None) -> List[Any]:
     """Generate a list of mocked results with property `prop`.
 
     One of the results is set to `expected`  and the rest are random values.
@@ -27,7 +30,7 @@ def generate_mocked_results(mocker, target, instances=10, expected=None):
     return results
 
 
-def test_select_max_list(mocker):
+def test_select_max_list(mocker: MockFixture):
     """Test select_max using mocked results."""
     results = generate_mocked_results(
         mocker, 'qmflows.packages.SCM.ADF_Result', expected=1e3)
@@ -37,7 +40,7 @@ def test_select_max_list(mocker):
     assertion.eq(xs.prop, 1e3)
 
 
-def test_select_min(mocker):
+def test_select_min(mocker: MockFixture):
     """Test select_min using mocked results."""
     results = generate_mocked_results(
         mocker, 'qmflows.packages.SCM.DFTB_Result', expected=-1e3)

--- a/test/test_orca_mock.py
+++ b/test/test_orca_mock.py
@@ -1,7 +1,7 @@
 """Mock orca funcionality."""
 import numpy as np
 from assertionlib import assertion
-from pytest_mock import mocker
+from pytest_mock import MockFixture
 from scm.plams import Molecule
 
 from qmflows import Settings, orca
@@ -11,7 +11,7 @@ from qmflows.test_utils import PATH, PATH_MOLECULES
 WORKDIR = PATH / "output_orca"
 
 
-def test_orca_mock(mocker):
+def test_orca_mock(mocker: MockFixture):
     """Mock a call to orca."""
     methanol = Molecule(PATH_MOLECULES / "methanol.xyz")
 


### PR DESCRIPTION
## Changes
the mocked test are redefining the mocker object like:
```pyhon
from pytest_mock import mocker

def test_foo(mocker):
...
```
The `import` statement is not necessary because pytest is already adding the `mocker` object.
