### PR TITLE
Make `Package` instances compatible with `builtins.function`

### DIFF
--- a/src/qmflows/packages/SCM.py
+++ b/src/qmflows/packages/SCM.py
@@ -199,8 +199,8 @@ class ADF(Package):
     generic_mapping: ClassVar[_Settings] = load_properties('ADF', prefix='generic2')
     result_type: ClassVar[Type[Result]] = ADF_Result
 
-    def __init__(self) -> None:
-        super(ADF, self).__init__("adf")
+    def __init__(self, pkg_name: str = "adf") -> None:
+        super().__init__(pkg_name)
 
     @classmethod
     def run_job(cls, settings: Settings, mol: plams.Molecule,
@@ -265,8 +265,8 @@ class DFTB(Package):
     generic_mapping: ClassVar[_Settings] = load_properties('DFTB', prefix='generic2')
     result_type: ClassVar[Type[Result]] = DFTB_Result
 
-    def __init__(self) -> None:
-        super().__init__("dftb")
+    def __init__(self, pkg_name: str = "dftb") -> None:
+        super().__init__(pkg_name)
 
     @classmethod
     def run_job(cls, settings: Settings, mol: plams.Molecule, job_name: str,

--- a/src/qmflows/packages/cp2k_mm.py
+++ b/src/qmflows/packages/cp2k_mm.py
@@ -48,8 +48,8 @@ class CP2KMM(CP2K):
     generic_mapping: ClassVar[_Settings] = load_properties('CP2KMM', prefix='generic2')
     result_type: ClassVar[Type[Result]] = CP2KMM_Result
 
-    def __init__(self) -> None:
-        super().__init__()
+    def __init__(self, pkg_name: str = "cp2k") -> None:
+        super().__init__(pkg_name)
 
     def prerun(self, settings: Settings, mol: plams.Molecule, **kwargs: Any) -> None:
         """Run a set of tasks before running the actual job."""

--- a/src/qmflows/packages/cp2k_package.py
+++ b/src/qmflows/packages/cp2k_package.py
@@ -48,8 +48,8 @@ class CP2K(Package):
     generic_mapping: ClassVar[_Settings] = load_properties('CP2K', prefix='generic2')
     result_type: ClassVar[Type[Result]] = CP2K_Result
 
-    def __init__(self) -> None:
-        super().__init__("cp2k")
+    def __init__(self, pkg_name: str = "cp2k") -> None:
+        super().__init__(pkg_name)
 
     @classmethod
     def run_job(cls, settings: Settings, mol: plams.Molecule,

--- a/src/qmflows/packages/orca.py
+++ b/src/qmflows/packages/orca.py
@@ -51,8 +51,8 @@ class ORCA(Package):
     generic_mapping: ClassVar[_Settings] = load_properties('ORCA', prefix='generic2')
     result_type: ClassVar[Type[Result]] = ORCA_Result
 
-    def __init__(self) -> None:
-        super().__init__("orca")
+    def __init__(self, pkg_name: str = "orca") -> None:
+        super().__init__(pkg_name)
 
     @classmethod
     def run_job(cls, settings: Settings, mol: plams.Molecule,

--- a/src/qmflows/packages/packages.py
+++ b/src/qmflows/packages/packages.py
@@ -286,6 +286,11 @@ class Package(ABC):
         """
         self.pkg_name = pkg_name
 
+        # Ensure compatibility with the (typing-only) `builtins.function` class
+        self.__name__: str = pkg_name
+        self.__qualname__: str = pkg_name
+        self.__annotations__: Dict[str, Any] = type(self).__call__.__annotations__
+
     @schedule(
         display="Running {self.pkg_name} {job_name}...",
         store=True, confirm=True)

--- a/test/test_sphinx.py
+++ b/test/test_sphinx.py
@@ -1,9 +1,11 @@
 """Test the :mod:`sphinx` documentation generation."""
 
 import shutil
+import warnings
 from os.path import join, isdir
 
 from sphinx.application import Sphinx
+from sphinx.errors import SphinxWarning
 
 SRCDIR = CONFDIR = 'docs'
 OUTDIR = join('tests', 'test_files', 'build')
@@ -16,6 +18,12 @@ def test_sphinx_build() -> None:
         app = Sphinx(SRCDIR, CONFDIR, OUTDIR, DOCTREEDIR,
                      buildername='html', warningiserror=True)
         app.build(force_all=True)
+    except SphinxWarning as ex:
+        # Do not raise if the exception is connection related
+        if "Max retries exceeded" not in str(ex):
+            raise
+        else:
+            warnings.warn(ex)
     finally:
         if isdir(OUTDIR):
             shutil.rmtree(OUTDIR)


### PR DESCRIPTION
This PR adds three new attributes to `Package`, thus making its instances fully compatible with `typing.Callable` (or more specifically the typing-only `builtins.function` class).

Note that this does not affect the `Package` *class*, only its instances are affected which are callables in their own right.