### PR TITLE
Add the `validate_output` keyword to `Package`

### DIFF
--- a/src/qmflows/packages/SCM.py
+++ b/src/qmflows/packages/SCM.py
@@ -205,6 +205,7 @@ class ADF(Package):
     @classmethod
     def run_job(cls, settings: Settings, mol: plams.Molecule,
                 job_name: str = 'ADFjob', nproc: Optional[int] = None,
+                validate_output: bool = True,
                 **kwargs: Any) -> ADF_Result:
         """Execute ADF job.
 
@@ -271,6 +272,7 @@ class DFTB(Package):
     @classmethod
     def run_job(cls, settings: Settings, mol: plams.Molecule, job_name: str,
                 work_dir: Union[None, str, os.PathLike] = None,
+                validate_output: bool = True,
                 **kwargs: Any) -> DFTB_Result:
         """Execute an DFTB job with the AMS driver.
 

--- a/src/qmflows/packages/cp2k_mm.py
+++ b/src/qmflows/packages/cp2k_mm.py
@@ -93,6 +93,7 @@ class CP2KMM(CP2K):
     def run_job(cls, settings: Settings, mol: plams.Molecule,
                 job_name: str = 'cp2k_job',
                 work_dir: Union[None, str, os.PathLike] = None,
+                validate_output: bool = True,
                 **kwargs: Any) -> CP2KMM_Result:
         """Call the Cp2K binary using plams interface.
 
@@ -120,8 +121,12 @@ class CP2KMM(CP2K):
 
         work_dir = work_dir if work_dir is not None else job.path
 
-        warnings = parse_output_warnings(job_name, r.job.path,
-                                         parse_cp2k_warnings, cp2k_warnings)
+        if validate_output:
+            warnings = parse_output_warnings(
+                job_name, r.job.path, parse_cp2k_warnings, cp2k_warnings
+            )
+        else:
+            warnings = None
 
         # Absolute path to the .dill file
         dill_path = join(job.path, f'{job.name}.dill')

--- a/src/qmflows/packages/cp2k_package.py
+++ b/src/qmflows/packages/cp2k_package.py
@@ -55,6 +55,7 @@ class CP2K(Package):
     def run_job(cls, settings: Settings, mol: plams.Molecule,
                 job_name: str = 'cp2k_job',
                 work_dir: Union[None, str, os.PathLike] = None,
+                validate_output: bool = True,
                 **kwargs: Any) -> CP2K_Result:
         """Call the Cp2K binary using plams interface.
 
@@ -86,8 +87,12 @@ class CP2K(Package):
 
         work_dir = work_dir if work_dir is not None else job.path
 
-        warnings = parse_output_warnings(job_name, r.job.path,
-                                         parse_cp2k_warnings, cp2k_warnings)
+        if validate_output:
+            warnings = parse_output_warnings(
+                job_name, r.job.path, parse_cp2k_warnings, cp2k_warnings
+            )
+        else:
+            warnings = None
 
         # Absolute path to the .dill file
         dill_path = join(job.path, f'{job.name}.dill')

--- a/src/qmflows/packages/orca.py
+++ b/src/qmflows/packages/orca.py
@@ -58,6 +58,7 @@ class ORCA(Package):
     def run_job(cls, settings: Settings, mol: plams.Molecule,
                 job_name: str = "ORCAjob",
                 work_dir: Union[None, str, os.PathLike] = None,
+                validate_output: bool = True,
                 **kwargs: Any) -> ORCA_Result:
 
         orca_settings = Settings()

--- a/src/qmflows/packages/package_wrapper.py
+++ b/src/qmflows/packages/package_wrapper.py
@@ -232,6 +232,7 @@ class PackageWrapper(Package, Generic[JT]):
     def run_job(self, settings: Settings, mol: plams.Molecule,
                 job_name: str = 'job',
                 work_dir: Union[None, str, os.PathLike] = None,
+                validate_output: bool = True,
                 **kwargs: Any) -> ResultWrapper:
         """Run the job and pass the resulting :class:`plams.Results<scm.plams.core.results.Results>` object to :class:`ResultWrapper`."""  # noqa
         # Input modifications

--- a/src/qmflows/packages/packages.py
+++ b/src/qmflows/packages/packages.py
@@ -304,8 +304,8 @@ class Package(ABC):
         display="Running {self.pkg_name} {job_name}...",
         store=True, confirm=True)
     def __call__(self, settings: Settings,
-                 mol: MolType,
-                 job_name: str = '', **kwargs: Any) -> Result:
+                 mol: MolType, job_name: str = '',
+                 validate_output: bool = True, **kwargs: Any) -> Result:
         r"""Perform a job with the package specified by :attr:`Package.pkg_name`.
 
         Parameters
@@ -316,6 +316,10 @@ class Package(ABC):
             A PLAMS or RDKit molecule to-be passed to the calculation.
         job_name : :class:`str`
             The name of the job.
+        validate_output : :class:`bool`
+            If :data:`True`, perform a package-specific validation of the output files' content.
+            Only relevant if the particular :class:`Package` subclass has
+            actually implemented output validation.
         \**kwargs : :data:`~typing.Any`
             Further keyword arguments to-be passed to :meth:`Package.prerun`,
             :meth:`Package.run_job` and :meth:`Package.post_run`.
@@ -326,6 +330,8 @@ class Package(ABC):
             A new Result instance.
 
         """  # noqa
+        kwargs['validate_output'] = validate_output
+
         # Ensure that these variables have an actual value
         # Precaution against passing unbound variables to self.postrun()
         output_warnings = plams_mol = job_settings = None
@@ -525,6 +531,7 @@ class Package(ABC):
     @abstractmethod
     def run_job(cls, settings: Settings, mol: plams.Molecule, job_name: str,
                 work_dir: Union[None, str, os.PathLike] = None,
+                validate_output: bool = False,
                 **kwargs: Any) -> Result:
         r"""`Abstract method <https://docs.python.org/3/library/abc.html#abc.abstractmethod>`_; should be implemented by the child class.
 
@@ -541,6 +548,10 @@ class Package(ABC):
             The name of the job.
         workdir : :class:`str` or :class:`~os.PathLike`, optional
             The path+folder name of the PLAMS working directory.
+        validate_output : :class:`bool`
+            If :data:`True`, perform a package-specific validation of the output files' content.
+            Only relevant if the particular :class:`Package` subclass has
+            actually implemented output validation.
         \**kwargs : :data:`~typing.Any`
             Further keyword arguments.
 

--- a/test/test_sphinx.py
+++ b/test/test_sphinx.py
@@ -23,7 +23,9 @@ def test_sphinx_build() -> None:
         if "Max retries exceeded" not in str(ex):
             raise
         else:
-            warnings.warn(ex)
+            warning = RuntimeWarning(str(ex))
+            warning.__cause__ = ex
+            warnings.warn(warning)
     finally:
         if isdir(OUTDIR):
             shutil.rmtree(OUTDIR)


### PR DESCRIPTION
This PR adds the `validate_output` keyword to `Package.__call__` and `run_job`, the determining whether or not the output should be checked for warnings.

The motivation behind this PR is the fact that output validation _can_ be very slow for large `.out` files,
situations wherein it is thus desirable to skip this step in its entirety.