### PR TITLE
Do not use the CP2K `USE_ELEMENT_AS_KIND` keyword

### DIFF
--- a/src/qmflows/packages/cp2k_mm.py
+++ b/src/qmflows/packages/cp2k_mm.py
@@ -168,7 +168,9 @@ class CP2KMM(CP2K):
         """Assign a .psf file."""
         subsys = settings.specific.cp2k.force_eval.subsys
         if value is None:
-            subsys.topology.use_element_as_kind = '.TRUE.'
+            symbol_list = sorted({at.symbol for at in mol})
+            for symbol in symbol_list:
+                subsys[f'kind {symbol}'].element = symbol
             return
 
         symbol_map = _map_psf_atoms(None, key, value, None)


### PR DESCRIPTION
The CP2K [`USE_ELEMENT_AS_KIND`](https://manual.cp2k.org/trunk/CP2K_INPUT/FORCE_EVAL/SUBSYS/TOPOLOGY.html#list_USE_ELEMENT_AS_KIND) ensures that an atom kind is automatically generated for each atomic symbol in the molecule. Because of this the keyword is automatically set to `.TRUE.` if no .psf file has been provided.

The problem is that this is a relatively new keyword (CP2K >= 7 I believe?). 
This PR thus removes the `USE_ELEMENT_AS_KIND` key and instead explicitly specifies a `kind` block for each individual atomic symbol.

