### PR TITLE
MAINT: Remove the cell parameters from the `cp2k_mm` templates

### DIFF
--- a/src/qmflows/templates/templates.py
+++ b/src/qmflows/templates/templates.py
@@ -81,7 +81,6 @@ specific:
                         ewald_type: NONE
             subsys:
                 cell:
-                    abc: '[angstrom] 50.0 50.0 50.0'
                     periodic: NONE
                 topology:
                     coord_file_format: 'OFF'
@@ -174,7 +173,6 @@ specific:
                         ewald_type: NONE
             subsys:
                 cell:
-                    abc: '[angstrom] 50.0 50.0 50.0'
                     periodic: NONE
                 topology:
                     coord_file_format: 'OFF'
@@ -276,7 +274,6 @@ specific:
                         ewald_type: NONE
             subsys:
                 cell:
-                    abc: '[angstrom] 50.0 50.0 50.0'
                     periodic: NONE
                 topology:
                     coord_file_format: 'OFF'
@@ -331,7 +328,6 @@ specific:
                         ewald_type: NONE
             subsys:
                 cell:
-                    abc: '[angstrom] 50.0 50.0 50.0'
                     periodic: NONE
                 topology:
                     coord_file_format: 'OFF'

--- a/src/qmflows/test_utils.py
+++ b/src/qmflows/test_utils.py
@@ -185,4 +185,5 @@ def get_mm_settings() -> Settings:
     s.charge = charge
     s.lennard_jones = lj
     s.periodic = 'none'
+    s.cell_parameters = [50, 50, 50]
     return s


### PR DESCRIPTION
The issue with supplying with the CP2K [`cell.abc`](https://manual.cp2k.org/trunk/CP2K_INPUT/FORCE_EVAL/SUBSYS/CELL.html#ABC) key is that it complicates the use of a number of other keys 
(_i.e._ `a`, `b` and `c`). Better remove it and let the user explicitly specify a value.

