### PR TITLE
BUG: Fixed an issue where `Result.__getattr__` could fail

### DIFF
--- a/src/qmflows/packages/packages.py
+++ b/src/qmflows/packages/packages.py
@@ -130,7 +130,10 @@ class Result:
             # Do not issue this warning if the Results object is still pickled
             else:  # Unpickle the Results instance and try again
                 self._unpack_results()
-                return self.__getattr__(prop)
+                try:
+                    return vars(self)[prop]  # Avoid recursive `getattr` calls
+                except KeyError:
+                    warn(f"Generic property {prop!r} not defined", category=QMFlows_Warning)
 
         elif has_crashed and not is_private:
             warn(f"""


### PR DESCRIPTION
Apparently the wrapper of `qmflows.Result` around `plams.Results` was failing to work when initially opening.

The problem was due to a recursive call `Result__getattr__`, a problem that has been resolved by directly performing a `__getitem__` operation on the classes' underlying  instance-attribute-containing dictionary.

Examples
----------
The previous behavior:
``` python
>>> from qmflows.packages import Result

>>> result: Result = ...
>>> result.get_hirshfeld_charges()  # Fails
None

>>> result.get_hirshfeld_charges()  # Works fine as the `plams.Result`-containing .dill file has been unpickled
[...]
```