### PR TITLE
ENH: Added the new `lattice` property to `CP2K_Result`

### DIFF
--- a/src/qmflows/data/dictionaries/propertiesCP2K.yaml
+++ b/src/qmflows/data/dictionaries/propertiesCP2K.yaml
@@ -51,3 +51,12 @@ volume:
     kwargs:
         column: -1
         start: 1
+lattice:
+    file_pattern: '*-1.cell'
+    function: read_cp2k_table_slc
+    parser: cp2KParser
+    kwargs:
+        shape: [-1, 3, 3]
+        column_start: 2
+        column_stop: 11
+        row_start: 1

--- a/src/qmflows/data/dictionaries/propertiesCP2KMM.yaml
+++ b/src/qmflows/data/dictionaries/propertiesCP2KMM.yaml
@@ -47,3 +47,12 @@ volume:
     kwargs:
         column: -1
         start: 1
+lattice:
+    file_pattern: '*-1.cell'
+    function: read_cp2k_table_slc
+    parser: cp2KParser
+    kwargs:
+        shape: [-1, 3, 3]
+        column_start: 2
+        column_stop: 11
+        row_start: 1

--- a/src/qmflows/packages/packages.py
+++ b/src/qmflows/packages/packages.py
@@ -684,18 +684,16 @@ def find_file_pattern(path: Union[str, os.PathLike],
 def ignore_unused_kwargs(fun: Callable, *args: Any, **kwargs: Any) -> Any:
     """Inspect the signature of function `fun` and filter the keyword arguments.
 
-    Searches for the keyword arguments which have a nonempty default values
-    and then the dict `kwargs` those key-value pairs ignoring the rest.
+    Searches for the keyword arguments that are present in both `**kwargs`
+    and the supplied `fun`; all others are discarded.
 
     """
+    # Find the intersction between `kwargs` and
+    # the (potential) parameters of `fun`
     ps = inspect.signature(fun).parameters
+    valid_keys = kwargs.keys() & ps.keys()
 
-    # Look for the arguments with the nonempty defaults.
-    defaults = filter(lambda t: t[1].default != inspect._empty, ps.items())
-
-    # *kwargs* may contain keyword arguments not supported by *fun*
-    # Extract from *kwargs* only the used keyword arguments
-    kwargs2 = {k: kwargs[k] for k, _ in defaults if k in kwargs}
+    kwargs2 = {k: kwargs[k] for k in valid_keys}
     return fun(*args, **kwargs2)
 
 

--- a/src/qmflows/parsers/cp2KParser.py
+++ b/src/qmflows/parsers/cp2KParser.py
@@ -29,7 +29,8 @@ from .parser import (floatNumber, minusOrplus, natural, point,
 from .xyzParser import manyXYZ, tuplesXYZ_to_plams
 
 __all__ = ['readCp2KBasis', 'read_cp2k_coefficients', 'get_cp2k_freq',
-           'read_cp2k_number_of_orbitals', 'read_cp2k_xyz', 'read_cp2k_table']
+           'read_cp2k_number_of_orbitals', 'read_cp2k_xyz', 'read_cp2k_table',
+           'read_cp2k_table_slc']
 
 
 # Starting logger
@@ -607,3 +608,31 @@ def read_cp2k_table(
     with open(path, 'r') as f:
         flat_iter = (i.split()[column] for i in islice(f, start, stop, step))
         return np.fromiter(flat_iter, dtype=dtype)
+
+
+def read_cp2k_table_slc(
+    path: PathLike,
+    shape: Sequence[int],
+    column_start: Optional_[int] = None,
+    column_stop: Optional_[int] = None,
+    column_step: Optional_[int] = None,
+    row_start: Optional_[int] = None,
+    row_stop: Optional_[int] = None,
+    row_step: Optional_[int] = None,
+    dtype: Any = np.float64,
+) -> np.ndarray:
+    """Extract an ND array of the given **shape** from **path**.
+
+    **column_start**, **column_stop** and **column_step** can be used for
+    specifiying the to-be parsed columns.
+    **start**, **stop** and **step** can be used for specifiying the to-be parsed rows.
+
+    """
+    with open(path, 'r') as f:
+        clm_slc = slice(column_start, column_stop, column_step)
+        row_slc = islice(f, row_start, row_stop, row_step)
+        flat_iter = chain.from_iterable(i.split()[clm_slc] for i in row_slc)
+
+        ret = np.fromiter(flat_iter, dtype=dtype)
+        ret.shape = shape
+        return ret


### PR DESCRIPTION
This PR adds the new `CP2K_Result.lattice` property, 
the latter returning all lattice vectors over the course of a trajectory; `shape = (n_mol, 3, 3)`.