### PR TITLE
MAINT:  Use `o_spline = 4` for all other `cp2k_mm` the templates

### DIFF
--- a/src/qmflows/templates/templates.py
+++ b/src/qmflows/templates/templates.py
@@ -79,6 +79,7 @@ specific:
                     periodic: NONE
                     ewald:
                         ewald_type: NONE
+                        o_spline: 4
             subsys:
                 cell:
                     periodic: NONE
@@ -171,6 +172,7 @@ specific:
                     periodic: NONE
                     ewald:
                         ewald_type: NONE
+                        o_spline: 4
             subsys:
                 cell:
                     periodic: NONE
@@ -272,6 +274,7 @@ specific:
                     periodic: NONE
                     ewald:
                         ewald_type: NONE
+                        o_spline: 4
             subsys:
                 cell:
                     periodic: NONE
@@ -326,6 +329,7 @@ specific:
                     periodic: NONE
                     ewald:
                         ewald_type: NONE
+                        o_spline: 4
             subsys:
                 cell:
                     periodic: NONE


### PR DESCRIPTION
Forgot to change the default `o_spline` values in the other `cp2k_mm` templates besides `cell_opt` (xref https://github.com/SCM-NV/qmflows/pull/239).