### PR TITLE
ENH: Ensure that the qmflows templates are always copied

### DIFF
--- a/.github/workflows/pythonapp.yml
+++ b/.github/workflows/pythonapp.yml
@@ -11,7 +11,7 @@ jobs:
       fail-fast: false
       matrix:
         os:  [macos-latest, ubuntu-latest]
-        version: [3.6, 3.7, 3.8, 3.9]
+        version: [3.7, 3.8, 3.9]
 
     steps:
     - uses: actions/checkout@v2

--- a/setup.py
+++ b/setup.py
@@ -58,9 +58,9 @@ setup(
         "qmflows": ['data/dictionaries/*yaml',
                     'py.typed']
     },
+    python_requires='>=3.7',
     classifiers=[
         'Intended Audience :: Science/Research',
-        'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',

--- a/src/qmflows/__init__.py
+++ b/src/qmflows/__init__.py
@@ -1,5 +1,7 @@
 """QMFlows API."""
 
+from __future__ import annotations
+
 from .__version__ import __version__
 
 from .logger import logger
@@ -13,7 +15,7 @@ from .components import (
 from .packages import (
     adf, cp2k, cp2k_mm, dftb, orca, run, PackageWrapper)
 
-from .templates import (freq, geometry, singlepoint, ts, md, cell_opt)
+from . import templates
 from .settings import Settings
 from .examples import (example_H2O2_TS, example_freqs, example_generic_constraints,
                        example_partial_geometry_opt)
@@ -28,3 +30,21 @@ __all__ = [
     'example_partial_geometry_opt',
     'freq', 'geometry', 'singlepoint', 'ts', 'md', 'cell_opt',
     'find_first_job', 'select_max', 'select_min']
+
+_TEMPLATES = frozenset(templates.__all__)
+_DIR_CACHE: None | list[str] = None
+
+
+def __getattr__(name: str) -> Settings:
+    """Ensure that the qmflows templates are always copied before returning."""
+    if name in _TEMPLATES:
+        return getattr(templates, name).copy()
+    raise AttributeError(f"module {__name__} has no attribute {name}")
+
+
+def __dir__() -> list[str]:
+    """Manually insert the qmflows templates into :func:`dir`."""
+    global _DIR_CACHE
+    if _DIR_CACHE is None:
+        _DIR_CACHE = sorted(list(globals()) + templates.__all__)
+    return _DIR_CACHE

--- a/test/test_templates.py
+++ b/test/test_templates.py
@@ -1,7 +1,10 @@
 """Test that the templates behave correctly."""
-from qmflows import Settings
+import qmflows
+from qmflows import Settings, templates
 from qmflows.templates import freq, geometry, singlepoint, ts
 from assertionlib import assertion
+
+import pytest
 
 
 def transform(x: Settings) -> Settings:
@@ -17,3 +20,12 @@ def test_templates():
     b4 = ts == transform(ts)
 
     assertion.truth(all((b1, b2, b3, b4)))
+
+
+@pytest.mark.parametrize("name", templates.__all__)
+def test_id(name: str) -> None:
+    """Test that getting a template returns a copy."""
+    s1 = getattr(qmflows, name)
+    s2 = getattr(qmflows, name)
+    assertion.eq(s1, s2)
+    assertion.is_not(s1, s2)


### PR DESCRIPTION
This PR adds a module-level `__getattr__` (see [PEP 562](https://www.python.org/dev/peps/pep-0562/)) in order to ensure that qmflows templates are 
always copied when getting them. This should prevent issues wherein the (extremelly mutable) settings 
instance is altered inplace, which can result in some rather nasty and difficult to diagnose bugs.