### PR TITLE
REV: Reintroduce support for python 3.6

### DIFF
--- a/.github/workflows/pythonapp.yml
+++ b/.github/workflows/pythonapp.yml
@@ -11,7 +11,7 @@ jobs:
       fail-fast: false
       matrix:
         os:  [macos-latest, ubuntu-latest]
-        version: [3.7, 3.8, 3.9]
+        version: [3.6, 3.7, 3.8, 3.9]
 
     steps:
     - uses: actions/checkout@v2

--- a/setup.py
+++ b/setup.py
@@ -58,9 +58,10 @@ setup(
         "qmflows": ['data/dictionaries/*yaml',
                     'py.typed']
     },
-    python_requires='>=3.7',
+    python_requires='>=3.6',
     classifiers=[
         'Intended Audience :: Science/Research',
+        'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',

--- a/src/qmflows/__init__.py
+++ b/src/qmflows/__init__.py
@@ -1,6 +1,7 @@
 """QMFlows API."""
 
-from __future__ import annotations
+import sys
+from typing import TYPE_CHECKING
 
 from .__version__ import __version__
 
@@ -31,20 +32,24 @@ __all__ = [
     'freq', 'geometry', 'singlepoint', 'ts', 'md', 'cell_opt',
     'find_first_job', 'select_max', 'select_min']
 
-_TEMPLATES = frozenset(templates.__all__)
-_DIR_CACHE: None | list[str] = None
+if TYPE_CHECKING or sys.version_info < (3, 7):
+    from .templates import freq, geometry, singlepoint, ts, md, cell_opt
+else:
+    _TEMPLATES = frozenset(templates.__all__)
+    _DIR_CACHE: "None | list[str]" = None
 
+    def __getattr__(name: str) -> Settings:
+        """Ensure that the qmflows templates are always copied before returning."""
+        if name in _TEMPLATES:
+            return getattr(templates, name).copy()
+        raise AttributeError(f"module {__name__} has no attribute {name}")
 
-def __getattr__(name: str) -> Settings:
-    """Ensure that the qmflows templates are always copied before returning."""
-    if name in _TEMPLATES:
-        return getattr(templates, name).copy()
-    raise AttributeError(f"module {__name__} has no attribute {name}")
+    def __dir__() -> "list[str]":
+        """Manually insert the qmflows templates into :func:`dir`."""
+        global _DIR_CACHE
+        if _DIR_CACHE is None:
+            _DIR_CACHE = sorted(list(globals()) + templates.__all__)
+        return _DIR_CACHE
 
-
-def __dir__() -> list[str]:
-    """Manually insert the qmflows templates into :func:`dir`."""
-    global _DIR_CACHE
-    if _DIR_CACHE is None:
-        _DIR_CACHE = sorted(list(globals()) + templates.__all__)
-    return _DIR_CACHE
+# Clean up the namespace
+del sys, TYPE_CHECKING

--- a/test/test_templates.py
+++ b/test/test_templates.py
@@ -1,4 +1,6 @@
 """Test that the templates behave correctly."""
+
+import sys
 import qmflows
 from qmflows import Settings, templates
 from qmflows.templates import freq, geometry, singlepoint, ts
@@ -23,6 +25,7 @@ def test_templates():
 
 
 @pytest.mark.parametrize("name", templates.__all__)
+@pytest.mark.skipif(sys.version_info < (3, 7), reason="Requires python >= 3.7")
 def test_id(name: str) -> None:
     """Test that getting a template returns a copy."""
     s1 = getattr(qmflows, name)


### PR DESCRIPTION
cc @rlKoekie.

I wasn't aware that SCM was still shipping Python 3.6.

Out of curiosity, are there any plans for updating the SCM-distributed python version?
Considering 3.6 is almost 5 years old at this point.