### PR TITLE
ENH: Add a generic keyword for the CP2K `GAL19` non-bonded forcefield

### DIFF
--- a/src/qmflows/cp2k_utils.py
+++ b/src/qmflows/cp2k_utils.py
@@ -66,6 +66,7 @@ CP2K_KEYS_ALIAS: Dict[str, Tuple[str, ...]] = {
     'buck4ranges': _BASE_PATH + ('nonbonded', 'buck4ranges'),
     'buckmorse': _BASE_PATH + ('nonbonded', 'buckmorse'),
     'eam': _BASE_PATH + ('nonbonded', 'eam'),
+    'gal19': _BASE_PATH + ('nonbonded', 'gal19'),
     'genpot': _BASE_PATH + ('nonbonded', 'genpot'),
     'goodwin': _BASE_PATH + ('nonbonded', 'goodwin'),
     'ipbv': _BASE_PATH + ('nonbonded', 'ipbv'),


### PR DESCRIPTION
Added in CP2K version 8; see the [CP2K manual](https://manual.cp2k.org/cp2k-8_2-branch/CP2K_INPUT/FORCE_EVAL/MM/FORCEFIELD/NONBONDED/GAL19.html).