### PR TITLE
TST: Re-enable the CP2K tests

### DIFF
--- a/.github/workflows/pythonapp.yml
+++ b/.github/workflows/pythonapp.yml
@@ -32,11 +32,11 @@ jobs:
     - uses: actions/checkout@v2
 
     - name: Install cp2k
-      if: matrix.os == 'DISABLE'
+      if: matrix.os == 'ubuntu-latest'
       run: sudo apt install cp2k --fix-missing
 
     - name: Info CP2K
-      if: matrix.os == 'DISABLE'
+      if: matrix.os == 'ubuntu-latest'
       run: cp2k.popt --version
 
     - name: Setup conda

--- a/.github/workflows/pythonapp.yml
+++ b/.github/workflows/pythonapp.yml
@@ -48,21 +48,21 @@ jobs:
     - name: Install dependencies
       if: matrix.special == ''
       run: |
-        conda create -n test -c conda-forge python=${{ matrix.version }} h5py rdkit nbsphinx jupyter
+        conda create -n test -c conda-forge python=${{ matrix.version }} h5py rdkit nbsphinx jupyter pandoc
         source $CONDA/bin/activate test
         pip install -e .[test]
 
     - name: Install dependencies (pre-release)
       if: matrix.special == 'pre-release'
       run: |
-        conda create -n test -c conda-forge python=${{ matrix.version }} h5py rdkit nbsphinx jupyter
+        conda create -n test -c conda-forge python=${{ matrix.version }} h5py rdkit nbsphinx jupyter pandoc
         source $CONDA/bin/activate test
         pip install --pre -e .[test] --upgrade --force-reinstall
 
     - name: Install dependencies (no RDKit)
       if: matrix.special == 'no RDKit'
       run: |
-        conda create -n test -c conda-forge python=${{ matrix.version }} h5py nbsphinx jupyter
+        conda create -n test -c conda-forge python=${{ matrix.version }} h5py nbsphinx jupyter pandoc
         source $CONDA/bin/activate test
         pip install -e .[test]
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -183,11 +183,6 @@ texinfo_documents = [
 ]
 
 
-# Output is processed with HTML4 writer.
-# Default is False.
-html4_writer = True
-
-
 # True to use the .. admonition:: directive for the Example and Examples sections.
 # False to use the .. rubric:: directive instead. One may look better than the other depending on what HTML theme is used.
 # Defaults to False.

--- a/setup.py
+++ b/setup.py
@@ -78,7 +78,7 @@ setup(
         'pandas',
         'noodles==0.3.3',
         'plams>=1.5.1',
-        'pyparsing',
+        'pyparsing<3.0',
         'pyyaml>=5.1',
         'filelock',
     ],

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,8 @@ docs_require = [
     'sphinx-autodoc-typehints',
     'sphinx_rtd_theme',
     'nbsphinx',
-    'jupyter'
+    'jupyter',
+    'pandoc',
 ]
 
 tests_require =  [
@@ -84,6 +85,6 @@ setup(
     ],
     extras_require={
         'test': tests_require,
-        'doc': tests_require
+        'doc': docs_require,
     }
 )


### PR DESCRIPTION
Closes https://github.com/SCM-NV/qmflows/issues/250.

The `sudo apt install cp2k` command was broken some time ago, see if it is working again.