### PR TITLE
MAINT: Up the stacklevel of `Result.__getattr__` warnings

### DIFF
--- a/src/qmflows/packages/packages.py
+++ b/src/qmflows/packages/packages.py
@@ -131,7 +131,7 @@ class Result:
         elif not (has_crashed or is_private or prop in self.prop_mapping):
             if self._results_open:
                 warn(f"Generic property {prop!r} not defined",
-                     category=QMFlows_Warning)
+                     category=QMFlows_Warning, stacklevel=2)
 
             # Do not issue this warning if the Results object is still pickled
             else:  # Unpickle the Results instance and try again
@@ -139,7 +139,8 @@ class Result:
                 try:
                     return vars(self)[prop]  # Avoid recursive `getattr` calls
                 except KeyError:
-                    warn(f"Generic property {prop!r} not defined", category=QMFlows_Warning)
+                    warn(f"Generic property {prop!r} not defined",
+                         category=QMFlows_Warning, stacklevel=2)
 
         elif has_crashed and not is_private:
             warn(f"""
@@ -148,7 +149,7 @@ class Result:
             Are you sure that you have the package installed or
              you have loaded the package in the cluster. For example:
             `module load AwesomeQuantumPackage/3.141592`
-            """, category=QMFlows_Warning)
+            """, category=QMFlows_Warning, stacklevel=2)
         return None
 
     def get_property(self, prop: str) -> Any:

--- a/test/test_adf_mock.py
+++ b/test/test_adf_mock.py
@@ -1,4 +1,9 @@
 """Mock the ADF output."""
+
+from pathlib import Path
+from typing import Optional
+
+import pytest
 from assertionlib import assertion
 from pytest_mock import MockFixture
 from scm.plams import Molecule
@@ -6,6 +11,8 @@ from scm.plams import Molecule
 from qmflows import adf, templates
 from qmflows.packages.SCM import ADF_Result
 from qmflows.test_utils import PATH, PATH_MOLECULES
+from qmflows.warnings_qmflows import QMFlows_Warning
+from qmflows.utils import InitRestart
 
 WORKDIR = PATH / "output_adf"
 
@@ -38,3 +45,32 @@ def test_adf_mock(mocker: MockFixture):
     mol = rs.molecule
     assertion.isinstance(mol, Molecule)
     assertion.len_eq(mol, 6)  # there are 6 atoms
+
+
+@pytest.mark.parametrize("name,match,status", [
+    ("bob", "Generic property 'bob' not defined", None),
+    ("energy", "It is not possible to retrieve property: 'energy'", "crashed"),
+], ids=["undefined_property", "job_crashed"])
+def test_getattr_warning(tmp_path: Path, name: str, match: str, status: Optional[str]) -> None:
+    mol = Molecule(PATH_MOLECULES / "acetonitrile.xyz")
+    jobname = "ADFjob"
+    dill_path = WORKDIR / jobname / "ADFjob.dill"
+    plams_dir = WORKDIR / jobname
+    result = ADF_Result(templates.geometry, mol, jobname,
+                        dill_path=dill_path, work_dir=plams_dir,
+                        plams_dir=plams_dir)
+    if status is not None:
+        result.status = status
+
+    # Need to fire up `plams.init` so the .dill file can be unpickled by `plams.load_job`
+    with InitRestart(tmp_path):
+        with pytest.warns(QMFlows_Warning, match=match) as rec:
+            getattr(result, name)
+            assertion.len_eq(rec.list, 1)
+            assertion.eq(rec.list[0].filename, __file__)
+
+        # Test a second time after the .dill file has been unpickled
+        with pytest.warns(QMFlows_Warning, match=match) as rec:
+            getattr(result, name)
+            assertion.len_eq(rec.list, 1)
+            assertion.eq(rec.list[0].filename, __file__)


### PR DESCRIPTION
Up the stacklevel so the warning points directly to the location of the relevant `getattr` operation.