### PR TITLE
MAINT: Account for the different .MOLog structure of CP2K >= 8.2

### DIFF
--- a/src/qmflows/parsers/cp2KParser.py
+++ b/src/qmflows/parsers/cp2KParser.py
@@ -5,6 +5,7 @@ import logging
 import mmap
 import os
 import subprocess
+import warnings
 from itertools import islice, chain
 from pathlib import Path
 from typing import Any, Dict, FrozenSet, Generator, Iterable, List, IO
@@ -730,4 +731,5 @@ def get_cp2k_version(out_file: PathLike) -> CP2KVersion:
                     return CP2KVersion._make(int(i) for i in version_str.split("."))
                 except ValueError:
                     pass
-        return CP2KVersion(0, 0)
+    warnings.warn("Failed to identify the CP2K version", QMFlows_Warning, stacklevel=2)
+    return CP2KVersion(0, 0)


### PR DESCRIPTION
CP2K >= 8.2 prints all MOs in the log file, rather than just the ones specified in [MO_INDEX_RANGE](https://manual.cp2k.org/trunk/CP2K_INPUT/FORCE_EVAL/DFT/PRINT/MO.html#MO_INDEX_RANGE).