### PR TITLE
BUG: Allow the `mpirun`/`srun` commands to have a prefix when parsing PLAMS .run files

### DIFF
--- a/src/qmflows/parsers/cp2KParser.py
+++ b/src/qmflows/parsers/cp2KParser.py
@@ -737,7 +737,7 @@ def get_cp2k_version(out_file: PathLike) -> CP2KVersion:
     return CP2KVersion(0, 0)
 
 
-EXECUTABLE_PATTERN = re.compile(r"(mpirun|srun)\s*(\S+)")
+EXECUTABLE_PATTERN = re.compile(r"(\S+)?(mpirun|srun)\s*(\S+)")
 VERSION_PATTERN = re.compile(r"\s+CP2K version (\d+).(\d+)")
 
 
@@ -748,7 +748,7 @@ def get_cp2k_version_run(run_file: PathLike) -> CP2KVersion:
         for i in f:
             match = EXECUTABLE_PATTERN.match(i)
             if match is not None:
-                executable = match.groups()[1]
+                executable = match.groups()[2]
                 break
         else:
             filename = os.fsdecode(run_file)


### PR DESCRIPTION
*e.g.* `/usr/bin/srun cp2k.psmp -i job.in -o job.out `