### PR TITLE
MAINT: Make the regex pattern for finding the CP2K executable more robust

### DIFF
--- a/src/qmflows/parsers/cp2KParser.py
+++ b/src/qmflows/parsers/cp2KParser.py
@@ -737,7 +737,7 @@ def get_cp2k_version(out_file: PathLike) -> CP2KVersion:
     return CP2KVersion(0, 0)
 
 
-EXECUTABLE_PATTERN = re.compile(r"(\S+)?(mpirun|srun)\s*(\S+)")
+EXECUTABLE_PATTERN = re.compile(r"(.+\s+)?(\S+)\s+-i")
 VERSION_PATTERN = re.compile(r"\s+CP2K version (\d+).(\d+)")
 
 
@@ -748,7 +748,7 @@ def get_cp2k_version_run(run_file: PathLike) -> CP2KVersion:
         for i in f:
             match = EXECUTABLE_PATTERN.match(i)
             if match is not None:
-                executable = match.groups()[2]
+                executable = match.groups()[1]
                 break
         else:
             filename = os.fsdecode(run_file)


### PR DESCRIPTION
Grab the first word before `-i`; this should be the executable.