### PR TITLE
MAINT: Allow the CP2K executable to contain spaces

### DIFF
--- a/src/qmflows/__init__.py
+++ b/src/qmflows/__init__.py
@@ -57,7 +57,7 @@ if TYPE_CHECKING or sys.version_info < (3, 7) or _RDKIT_EX is None:
     )
     from . import components, examples
 
-if sys.version_info >= (3, 7):
+if not TYPE_CHECKING and sys.version_info >= (3, 7):
     from ._init_utils import (
         getattr_method as __getattr__,
         dir_method as __dir__,
@@ -69,7 +69,6 @@ if sys.version_info >= (3, 7):
 else:
     # Initalize the sub-module such that `_RDKIT_EX` can enter its namespace
     from . import _init_utils
-    del _init_utils
 
 # Clean up the namespace
 del sys, TYPE_CHECKING, _RDKIT_EX

--- a/test/test_cp2k_parser.py
+++ b/test/test_cp2k_parser.py
@@ -1,4 +1,10 @@
 """Test CP2K parser functions."""
+
+import os
+import shutil
+from pathlib import Path
+
+import pytest
 from assertionlib import assertion
 
 from qmflows.parsers.cp2KParser import parse_cp2k_warnings, readCp2KBasis, get_cp2k_version_run
@@ -31,6 +37,46 @@ def test_read_basis():
 
 
 @requires_cp2k
-def test_get_cp2k_version() -> None:
-    out = get_cp2k_version_run(PATH / "cp2k_freq.run")
-    assertion.truth(out)
+class TestGetCP2KVersion:
+    @classmethod
+    def setup_class(cls) -> None:
+        """Add ``cp2k.popt`` to a space-containing directory and add it to ``$PATH``."""
+        cp2k_popt = shutil.which("cp2k.popt")
+        assert cp2k_popt is not None
+
+        os.mkdir(PATH / "test dir")
+        shutil.copy2(cp2k_popt, PATH / "test dir" / "cp2k.popt")
+
+    @classmethod
+    def teardown_class(cls) -> None:
+        """Restore the old ``$PATH`` environment variable."""
+        shutil.rmtree(PATH / "test dir")
+
+    PASS_DICT = {
+        "mpirun": "bin/mpirun cp2k.popt -i file.in -o file.out",
+        "srun": "srun cp2k.popt -i file.in -o file.out",
+        "none": "cp2k.popt -i file.in -o file.out",
+        "space": " cp2k.popt -i file.in -o file.out",
+        "single_quote": f"'{PATH}/test dir/cp2k.popt' -i file.in -o file.out",
+        "double_quote": f'"{PATH}/test dir/cp2k.popt" -i file.in -o file.out',
+    }
+
+    @pytest.mark.parametrize("name,txt", PASS_DICT.items(), ids=PASS_DICT)
+    def test_pass(self, name: str, txt: str, tmp_path: Path) -> None:
+        with open(tmp_path / f"{name}.run", "w") as f:
+            f.write(txt)
+        out = get_cp2k_version_run(tmp_path / f"{name}.run")
+        assertion.truth(out)
+
+    RAISE_DICT = {
+        "invalid_run": "cp2k.popt -j file.in -o file.out",
+        "invalid_exec": "cp2k.bob -i file.in -o file.out",
+        "invalid_exec_version": "python -i file.in -o file.out",
+    }
+
+    @pytest.mark.parametrize("name,txt", RAISE_DICT.items(), ids=RAISE_DICT)
+    def test_raise(self, name: str, txt: str, tmp_path: Path) -> None:
+        with open(tmp_path / f"{name}.run", "w") as f:
+            f.write(txt)
+        with pytest.raises(ValueError):
+            get_cp2k_version_run(tmp_path / f"{name}.run")


### PR DESCRIPTION
Allow the CP2K executable to contain spaces whenever extracting it from the .run file.