### PR TITLE
ENH: Add a frequency analysis template for CP2K

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Version 0.11.1 (Unreleased)
 
 ## New
- * n.a.
+ * Introduced a new template for frequency analyses with CP2K (#278).
 
 
 # Version 0.11.0 (17/11/2021)

--- a/src/qmflows/templates/templates.py
+++ b/src/qmflows/templates/templates.py
@@ -253,7 +253,27 @@ specific:
         dftb:
             resourcesdir: "DFTB.org/3ob-3-1"
 
-    cp2k : Null
+    cp2k:
+        force_eval:
+            dft:
+                mgrid:
+                    cutoff: 400
+                    ngrids: 4
+                qs:
+                    method: gpw
+                scf:
+                    eps_scf: 1e-06
+                    max_scf: 200
+                    scf_guess: restart
+            subsys:
+                cell:
+                    periodic: xyz
+        vibrational_analysis:
+            thermochemistry: .TRUE.
+        global:
+            print_level: low
+            project: cp2k
+            run_type: VIBRATIONAL_ANALYSIS
 
     cp2k_mm:
         force_eval:

--- a/test/test_using_plams/test_cp2k.py
+++ b/test/test_using_plams/test_cp2k.py
@@ -59,3 +59,19 @@ def test_cp2k_singlepoint(tmp_path: Path, mo_index_range: str) -> None:
     assertion.is_not(orbitals, None)
     np.testing.assert_allclose(orbitals.eigenvalues, ref.eigenvalues)
     np.testing.assert_allclose(np.abs(orbitals.eigenvectors).T, ref.eigenvectors)
+
+
+@requires_cp2k
+@pytest.mark.slow
+def test_cp2k_freq(tmp_path: Path) -> None:
+    """Run a simple single point."""
+    mol = Molecule(PATH_MOLECULES / "h2o.xyz", 'xyz', charge=0, multiplicity=1)
+    s = fill_cp2k_defaults(templates.freq)
+
+    job = cp2k(s, mol)
+    result = run(job, path=tmp_path, folder="test_cp2k_freq")
+
+    assertion.eq(result.status, "successful")
+    assertion.isclose(result.free_energy, -10801.971213467135)
+    assertion.isclose(result.enthalpy, -10790.423489727531)
+    np.testing.assert_allclose(result.frequencies, [1622.952012, 3366.668885, 3513.89377])


### PR DESCRIPTION
This PR adds the `qmflows.freq.cp2k` template, which can be used for performing frequency analyses.
The template is effectively a hybrid of the pre-existing `freq.cp2k_mm` and `singlepoint.cp2k` templates.