### PR TITLE
ENH: Add `Result.__dir__`

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ docs_require = [
 ]
 
 tests_no_optional_require = [
-    'assertionlib>=2.3.0',
+    'assertionlib>=3.1.0',
     'pytest>=5.4',
     'pytest-cov',
     'pytest-mock',

--- a/src/qmflows/packages/packages.py
+++ b/src/qmflows/packages/packages.py
@@ -13,7 +13,7 @@ from functools import partial
 from os.path import join
 from warnings import warn
 from typing import (
-    Any, Callable, Optional, Union, ClassVar, Mapping, Iterator, Type, Dict, TypeVar, Tuple
+    Any, Callable, Optional, Union, ClassVar, Mapping, Iterator, Type, Dict, TypeVar, Tuple, List
 )
 
 import numpy as np
@@ -151,6 +151,12 @@ class Result:
             `module load AwesomeQuantumPackage/3.141592`
             """, category=QMFlows_Warning, stacklevel=2)
         return None
+
+    def __dir__(self) -> List[str]:
+        """Implement ``dir(self)``."""
+        # Insert the highly dynamic `get_property`-based attributes
+        dir_set = set(super().__dir__()) | self.prop_mapping.keys()
+        return sorted(dir_set)
 
     def get_property(self, prop: str) -> Any:
         """Look for the optional arguments to parse a property, which are stored in the properties dictionary."""  # noqa

--- a/test/test_cp2k_mock.py
+++ b/test/test_cp2k_mock.py
@@ -114,3 +114,14 @@ def test_c2pk_freq_mock(mocker: MockFixture):
     # check properties
     assertion.isfinite(rs.enthalpy)
     assertion.isfinite(rs.free_energy)
+
+
+def test_dir(mocker: MockFixture) -> None:
+    s = fill_cp2k_defaults(templates.geometry)
+    jobname = "cp2k_opt"
+    run_mocked = mock_runner(mocker, jobname)
+
+    job = cp2k(s, ETHYLENE, job_name=jobname)
+    r = run_mocked(job)
+
+    assertion.issubset(CP2K_Result.prop_mapping.keys(), dir(r))


### PR DESCRIPTION
Adds the `Result.__dir__` method so that qmflows' generic properties are automatically picked up by autocompletion tools.