### PR TITLE
TST: Print the CP2K .out and .err files whenever a test job crashes

### DIFF
--- a/src/qmflows/packages/SCM.py
+++ b/src/qmflows/packages/SCM.py
@@ -105,7 +105,7 @@ class ADF_Result(Result):
                  dill_path: "None | str | os.PathLike[str]" = None,
                  plams_dir: "None | str | os.PathLike[str]" = None,
                  work_dir: "None | str | os.PathLike[str]" = None,
-                 status: str = 'done',
+                 status: str = 'successful',
                  warnings: Optional[WarnMap] = None) -> None:
         # Load available property parser from yaml file.
         super().__init__(settings, molecule, job_name, dill_path,
@@ -157,7 +157,7 @@ class DFTB_Result(Result):
                  dill_path: "None | str | os.PathLike[str]" = None,
                  plams_dir: "None | str | os.PathLike[str]" = None,
                  work_dir: "None | str | os.PathLike[str]" = None,
-                 status: str = 'done',
+                 status: str = 'successful',
                  warnings: Optional[WarnMap] = None) -> None:
         # Read available propiety parsers from a yaml file
         super().__init__(settings, molecule, job_name, dill_path,

--- a/src/qmflows/packages/packages.py
+++ b/src/qmflows/packages/packages.py
@@ -67,7 +67,7 @@ class Result:
                  dill_path: "None | str | os.PathLike[str]" = None,
                  plams_dir: "None | str | os.PathLike[str]" = None,
                  work_dir: "None | str | os.PathLike[str]" = None,
-                 status: str = 'done',
+                 status: str = 'successful',
                  warnings: Optional[WarnMap] = None) -> None:
         """Initialize a :class:`Result` instance.
 

--- a/test/test_using_plams/test_cp2k.py
+++ b/test/test_using_plams/test_cp2k.py
@@ -9,7 +9,13 @@ from assertionlib import assertion
 from scm.plams import Molecule
 
 from qmflows import Settings, cp2k, run, templates
-from qmflows.test_utils import PATH, PATH_MOLECULES, fill_cp2k_defaults, requires_cp2k
+from qmflows.test_utils import (
+    PATH,
+    PATH_MOLECULES,
+    fill_cp2k_defaults,
+    requires_cp2k,
+    validate_status,
+)
 
 
 @requires_cp2k
@@ -28,7 +34,7 @@ def test_cp2k_opt(tmp_path: Path) -> None:
     job = cp2k(s, water)
     result = run(job, path=tmp_path, folder="test_cp2k_opt")
 
-    assertion.eq(result.status, "successful")
+    validate_status(result)
     assertion.isinstance(result.molecule, Molecule)
 
 
@@ -57,7 +63,7 @@ def test_cp2k_singlepoint(tmp_path: Path, mo_index_range: str) -> None:
         key = f"test_using_plams/test_cp2k/test_cp2k_singlepoint/{mo_index_range}"
         ref = f[key][...].view(np.recarray)
 
-    assertion.eq(result.status, "successful")
+    validate_status(result)
     orbitals = result.orbitals
     assertion.is_not(orbitals, None)
     np.testing.assert_allclose(orbitals.eigenvalues, ref.eigenvalues)
@@ -74,7 +80,7 @@ def test_cp2k_freq(tmp_path: Path) -> None:
     job = cp2k(s, mol)
     result = run(job, path=tmp_path, folder="test_cp2k_freq")
 
-    assertion.eq(result.status, "successful")
+    validate_status(result)
     assertion.isclose(result.free_energy, -10801.971213467135)
     assertion.isclose(result.enthalpy, -10790.423489727531)
     np.testing.assert_allclose(result.frequencies, [1622.952012, 3366.668885, 3513.89377])

--- a/test/test_using_plams/test_cp2k_mm.py
+++ b/test/test_using_plams/test_cp2k_mm.py
@@ -6,7 +6,7 @@ from assertionlib import assertion
 from scm.plams import Molecule
 
 from qmflows import Settings, run, cp2k_mm, singlepoint, geometry, freq, md, cell_opt
-from qmflows.test_utils import get_mm_settings, PATH, PATH_MOLECULES, requires_cp2k
+from qmflows.test_utils import get_mm_settings, validate_status, PATH, PATH_MOLECULES, requires_cp2k
 
 MOL = Molecule(PATH_MOLECULES / 'Cd68Cl26Se55__26_acetate.xyz')
 
@@ -41,7 +41,7 @@ def test_singlepoint(tmp_path: Path) -> None:
 
     job = cp2k_mm(settings=s, mol=MOL, job_name='cp2k_mm_sp')
     result = run(job, path=tmp_path, folder="test_singlepoint")
-    assertion.eq(result.status, 'successful')
+    validate_status(result)
 
     # Compare energies
     ref = -15.4431781758
@@ -57,7 +57,7 @@ def test_geometry(tmp_path: Path) -> None:
 
     job = cp2k_mm(settings=s, mol=MOL, job_name='cp2k_mm_opt')
     result = run(job, path=tmp_path, folder="test_geometry")
-    assertion.eq(result.status, 'successful')
+    validate_status(result)
 
     # Compare energies
     ref = -16.865587192150834
@@ -84,7 +84,7 @@ def test_freq(tmp_path: Path) -> None:
 
     job = cp2k_mm(settings=s, mol=mol, job_name='cp2k_mm_freq')
     result = run(job, path=tmp_path, folder="test_freq")
-    assertion.eq(result.status, 'successful')
+    validate_status(result)
 
     freqs = result.frequencies
     freqs_ref = np.load(PATH / 'Cd68Cl26Se55__26_acetate.freq.npy')
@@ -109,7 +109,7 @@ def test_md(tmp_path: Path) -> None:
 
     job = cp2k_mm(settings=s, mol=mol, job_name='cp2k_mm_md')
     result = run(job, path=tmp_path, folder="test_md")
-    assertion.eq(result.status, 'successful')
+    validate_status(result)
 
     plams_results = result.results
     assertion.isfile(plams_results['cp2k-1_1000.restart'])
@@ -147,4 +147,4 @@ def test_c2pk_cell_opt(tmp_path: Path) -> None:
 
     job = cp2k_mm(settings=s, mol=mol, job_name='cp2k_mm_cell_opt')
     result = run(job, path=tmp_path, folder="test_c2pk_cell_opt")
-    assertion.eq(result.status, 'successful')
+    validate_status(result)


### PR DESCRIPTION
Print the last 100 lines of the .err and .out file whenever a test job crashes.