### PR TITLE
REV: Remove the `AtomBasisKey.alias` field again

### DIFF
--- a/src/qmflows/common.py
+++ b/src/qmflows/common.py
@@ -26,9 +26,6 @@ class AtomBasisKey(NamedTuple):
     #: The basis set format.
     basisFormat: Union[Sequence[int], Sequence[Tuple[str, int]]]
 
-    #: The primary basis key. Used if this instance is an alias of another `AtomBasisKey`.
-    alias: "None | AtomBasisKey" = None
-
 
 class AtomBasisData(NamedTuple):
     """Contraction coefficients and exponents for a gaussian basis."""

--- a/src/qmflows/parsers/_cp2k_basis_parser.py
+++ b/src/qmflows/parsers/_cp2k_basis_parser.py
@@ -63,7 +63,7 @@ def _read_basis(f: _BasisFileIter) -> _Basis2Tuple:
 
             for _ in range(n_sets):
                 # Parse the basis format, its exponents and its coefficients
-                basis_fmt = [int(j) for j in next(f).split()]
+                basis_fmt = tuple(int(j) for j in next(f).split())
                 n_exp = basis_fmt[3]
                 basis_data = np.array([j.split() for j in islice(f, 0, n_exp)], dtype=np.float64)
                 exp, coef = basis_data[:, 0], basis_data[:, 1:].T

--- a/src/qmflows/parsers/_cp2k_basis_parser.py
+++ b/src/qmflows/parsers/_cp2k_basis_parser.py
@@ -67,18 +67,9 @@ def _read_basis(f: _BasisFileIter) -> _Basis2Tuple:
                 n_exp = basis_fmt[3]
                 basis_data = np.array([j.split() for j in islice(f, 0, n_exp)], dtype=np.float64)
                 exp, coef = basis_data[:, 0], basis_data[:, 1:].T
-
-                # Two things happen whenever an basis set alias is encountered (i.e. `is_alias > 0`):
-                # 1. The `alias` field is set for the keys
-                # 2. The `AtomBasisData` instance, used for the original value, is reused
-                for is_alias, basis in enumerate(basis_list):
-                    if not is_alias:
-                        basis_key = AtomBasisKey(atom, basis, basis_fmt)
-                        basis_value = AtomBasisData(exp, coef)
-                        keys.append(basis_key)
-                    else:
-                        keys.append(AtomBasisKey(atom, basis, basis_fmt, alias=basis_key))
-                    values.append(basis_value)
+                for basis in basis_list:
+                    keys.append(AtomBasisKey(atom, basis, basis_fmt))
+                    values.append(AtomBasisData(exp, coef))
         except Exception as ex:
             raise ValueError(
                 f'Failed to parse the basis set "{atom} {basis_list[0]}" on line {f.index}'

--- a/test/test_cp2k_parser.py
+++ b/test/test_cp2k_parser.py
@@ -41,13 +41,10 @@ class TestReadBasis:
         with h5py.File(PATH / "basis.hdf5", "r") as f:
             for key_tup, value_tup in zip(keys, values):
                 key = self.get_key(key_tup)
-                group = f[key]
-                alias = group["alias"][...].astype(str)
-
-                np.testing.assert_allclose(value_tup.exponents, group["exponents"][...].T, err_msg=key)
-                np.testing.assert_allclose(value_tup.coefficients, group["coefficients"][...].T, err_msg=key)
-                if key_tup.alias is not None:
-                    assertion.eq(self.get_key(key_tup.alias), alias, message=key)
+                exponents = f[key]["exponents"][...].T
+                coefficients = f[key]["coefficients"][...].T
+                np.testing.assert_allclose(value_tup.exponents, exponents, err_msg=key)
+                np.testing.assert_allclose(value_tup.coefficients, coefficients, err_msg=key)
 
     PARAMS = {
         "BASIS_INVALID_N_EXP": 11,


### PR DESCRIPTION
Removed again, as it makes membership checks a lot more difficult in https://github.com/SCM-NV/nano-qmflows/pull/353.