### PR TITLE
BLD: Remove the upper version bound of noodles

### DIFF
--- a/.github/workflows/pythonapp.yml
+++ b/.github/workflows/pythonapp.yml
@@ -87,6 +87,7 @@ jobs:
             source $CONDA/bin/activate test
             pip install --pre -e .[test] --upgrade --force-reinstall
             pip install git+https://github.com/SCM-NV/PLAMS@master --upgrade
+            pip install git+https://github.com/NLeSC/noodles@master --upgrade
             ;;
           "no optional")
             conda create -n test -c conda-forge python=${{ matrix.version }}

--- a/setup.py
+++ b/setup.py
@@ -84,7 +84,7 @@ setup(
         'h5py',
         'numpy',
         'pandas',
-        'noodles==0.3.3',
+        'noodles>=0.3.3',
         'plams>=1.5.1',
         'pyparsing<3.0',
         'pyyaml>=5.1',


### PR DESCRIPTION
Allows for automatic installation of the new noodles 0.3.4 release.