### PR TITLE
BLD: Try removing the upper version bound of `pyparsing`

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -79,7 +79,7 @@ setup(
         'pandas',
         'noodles>=0.3.3',
         'plams>=1.5.1',
-        'pyparsing<3.0',
+        'pyparsing!=3.0.0',
         'pyyaml>=5.1',
         'filelock',
     ],


### PR DESCRIPTION
pyparsing >3.0 initially causes some test failures back in https://github.com/SCM-NV/qmflows/pull/255, check if those have now been resolved.