### PR TITLE
MAINT: Do not extract the CP2K version via `cp2k.popt --version`

### DIFF
--- a/test/test_cp2k_mock.py
+++ b/test/test_cp2k_mock.py
@@ -12,7 +12,6 @@ from qmflows import cp2k, templates
 from qmflows.packages.cp2k_package import CP2K_Result
 from qmflows.utils import init_restart
 from qmflows.common import CP2KVersion
-from qmflows.parsers.cp2KParser import get_cp2k_version_run
 from qmflows.test_utils import (
     PATH,
     PATH_MOLECULES,
@@ -20,11 +19,6 @@ from qmflows.test_utils import (
     requires_cp2k,
     validate_status,
 )
-
-try:
-    CP2K_VERSION = get_cp2k_version_run("cp2k.popt")
-except Exception:
-    CP2K_VERSION = CP2KVersion(0, 0)
 
 
 def mock_runner(mocker_instance, jobname: str) -> Callable[..., CP2K_Result]:
@@ -63,7 +57,6 @@ def test_deepcopy():
 
 # See https://github.com/SCM-NV/qmflows/issues/225
 @pytest.mark.xfail(raises=AssertionError)
-@pytest.mark.skipif(CP2K_VERSION >= (8, 2), reason="Requires CP2K < 8.2")
 @requires_cp2k
 def test_cp2k_singlepoint_mock(mocker: MockFixture):
     """Mock a call to CP2K."""

--- a/test/test_cp2k_parser.py
+++ b/test/test_cp2k_parser.py
@@ -9,7 +9,7 @@ import h5py
 import pytest
 from assertionlib import assertion
 
-from qmflows.parsers.cp2KParser import parse_cp2k_warnings, readCp2KBasis, get_cp2k_version_run
+from qmflows.parsers.cp2KParser import parse_cp2k_warnings, readCp2KBasis
 from qmflows.test_utils import PATH, requires_cp2k
 from qmflows.warnings_qmflows import QMFlows_Warning, cp2k_warnings
 from qmflows.common import AtomBasisKey
@@ -57,49 +57,3 @@ class TestReadBasis:
         pattern = r"Failed to parse the '.+' basis set on line {}".format(lineno)
         with pytest.raises(ValueError, match=pattern):
             readCp2KBasis(PATH / filename)
-
-
-@requires_cp2k
-class TestGetCP2KVersion:
-    @classmethod
-    def setup_class(cls) -> None:
-        """Add ``cp2k.popt`` to a space-containing directory and add it to ``$PATH``."""
-        cp2k_popt = shutil.which("cp2k.popt")
-        assert cp2k_popt is not None
-
-        os.mkdir(PATH / "test dir")
-        shutil.copy2(cp2k_popt, PATH / "test dir" / "cp2k.popt")
-
-    @classmethod
-    def teardown_class(cls) -> None:
-        """Restore the old ``$PATH`` environment variable."""
-        shutil.rmtree(PATH / "test dir")
-
-    PASS_DICT = {
-        "mpirun": "bin/mpirun cp2k.popt -i file.in -o file.out",
-        "srun": "srun cp2k.popt -i file.in -o file.out",
-        "none": "cp2k.popt -i file.in -o file.out",
-        "space": " cp2k.popt -i file.in -o file.out",
-        "single_quote": f"'{PATH}/test dir/cp2k.popt' -i file.in -o file.out",
-        "double_quote": f'"{PATH}/test dir/cp2k.popt" -i file.in -o file.out',
-    }
-
-    @pytest.mark.parametrize("name,txt", PASS_DICT.items(), ids=PASS_DICT)
-    def test_pass(self, name: str, txt: str, tmp_path: Path) -> None:
-        with open(tmp_path / f"{name}.run", "w") as f:
-            f.write(txt)
-        out = get_cp2k_version_run(tmp_path / f"{name}.run")
-        assertion.truth(out)
-
-    RAISE_DICT = {
-        "invalid_run": "cp2k.popt -j file.in -o file.out",
-        "invalid_exec": "cp2k.bob -i file.in -o file.out",
-        "invalid_exec_version": "python -i file.in -o file.out",
-    }
-
-    @pytest.mark.parametrize("name,txt", RAISE_DICT.items(), ids=RAISE_DICT)
-    def test_raise(self, name: str, txt: str, tmp_path: Path) -> None:
-        with open(tmp_path / f"{name}.run", "w") as f:
-            f.write(txt)
-        with pytest.raises(ValueError):
-            get_cp2k_version_run(tmp_path / f"{name}.run")


### PR DESCRIPTION
Using `cp2k.popt --version` can fail if the CP2K version used for constructing a given output is 
different from the version that's currently loaded.
Instead, read the version directly from the .out file.