### PR TITLE
ENH: Add two new fields to CP2K MO named tuple 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,13 @@
-# Version 0.12.1 (*unreleased*)
+# Version 0.12.1 (18/05/2022)
 
 ## New
- * *placeholder*.
+ * Add the MO index and occupation numbers to the CP2K orbital output.
+
+## Changed
+ * Explicitly raise when the line with the number of orbitals doesn't have any actual orbitals.
+
+## Fixed
+ * Fixed various bugs related to the parsing of unrestricted orbitals.
 
 
 # Version 0.12.0 (13/04/2022)

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,8 +1,9 @@
 # YAML 1.2
 # Metadata for citation of this software according to the CFF format (https://citation-file-format.github.io/)
-cff-version: 1.0.3
+cff-version: 1.2.0
 message: If you use this software, please cite it as below.
 title: QMflows
+abstract: QMflows library tackles the construction and efficient execution of computational chemistry workflows.
 doi: 10.5281/zenodo.1045523
 authors:
 - given-names: Felipe
@@ -22,7 +23,7 @@ keywords:
  - materials-science
  - python
  - Workflows
-version: '0.12.0'
-date-released: 2022-04-13  # YYYY-MM-DD
+version: '0.12.1'
+date-released: 2022-05-18  # YYYY-MM-DD
 repository-code: https://github.com/SCM-NV/qmflows
 license: "LGPL-3.0"

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,3 @@
+exclude test/*
+include src/qmflows/py.typed
+include src/qmflows/data/dictionaries/*yaml

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,7 +1,3 @@
-[metadata]
-description_file = README.rst
-license_file = LICENSE.md
-
 [aliases]
 # Define `python setup.py test`
 test = pytest

--- a/src/qmflows/_version.py
+++ b/src/qmflows/_version.py
@@ -1,3 +1,3 @@
 """The QMFlows version."""
 
-__version__ = "0.12.1.dev0"
+__version__ = "0.12.1"

--- a/src/qmflows/packages/_cp2k.py
+++ b/src/qmflows/packages/_cp2k.py
@@ -13,7 +13,7 @@ from ..parsers.cp2k import parse_cp2k_warnings
 from .._settings import Settings
 from ..warnings_qmflows import cp2k_warnings, Key_Warning
 from ..type_hints import Final, _Settings, Generic2Special
-from ..common import InfoMO
+from ..common import CP2KInfoMO
 
 if TYPE_CHECKING:
     from numpy.typing import NDArray
@@ -141,7 +141,7 @@ class CP2K_Result(Result):
     geometry: "None | plams.Molecule"
     enthalpy: "None | float"
     free_energy: "None | float"
-    orbitals: "None | InfoMO | tuple[InfoMO, InfoMO]"
+    orbitals: "None | CP2KInfoMO | tuple[CP2KInfoMO, CP2KInfoMO]"
     forces: "None | NDArray[f8]"
     coordinates: "None | NDArray[f8]"
     temperature: "None | NDArray[f8]"

--- a/test/test_common.py
+++ b/test/test_common.py
@@ -1,20 +1,27 @@
 import numpy as np
 from assertionlib import assertion
 
-from qmflows.common import InfoMO
+from qmflows.common import CP2KInfoMO
 
 
 class TestInfoMO:
     def test_array(self) -> None:
-        info_mo = InfoMO(
+        info_mo = CP2KInfoMO(
             eigenvalues=np.arange(3),
             eigenvectors=np.arange(12).reshape(4, 3),
+            orb_index=np.array([5, 6, 7]),
+            occupation=np.array([2.0, 2.0, 0.0]),
         )
         ref = np.array([
-            (0, [0, 3, 6, 9]),
-            (1, [1, 4, 7, 10]),
-            (2, [2, 5, 8, 11])
-        ], dtype=[("eigenvalues", "f8"), ("eigenvectors", "f8", (4,))])
+            (0, [0, 3, 6, 9], 5, 2),
+            (1, [1, 4, 7, 10], 6, 2),
+            (2, [2, 5, 8, 11], 7, 0),
+        ], dtype=[
+            ("eigenvalues", "f8"),
+            ("eigenvectors", "f8", (4,)),
+            ("orb_index", "i8"),
+            ("occupation", "f8"),
+        ])
 
         ar = np.array(info_mo)
         assertion.eq(ar.dtype, ref.dtype)


### PR DESCRIPTION
Add the MO index and occupation numbers to the CP2K orbital output.